### PR TITLE
Add Auto-detect button to Preferences; update README for v1.4–v2.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ A4, A4 Landscape, A3, A3 Landscape, A2, US Letter, Letter Landscape, Legal, Tabl
 - Double-density mode for ColorMunki/i1Studio with measuring rig (`-h` flag)
 - Live TIFF preview of the generated test chart
 - Direct TIFF printing via CUPS — color management forced off automatically, no manual option selection required, no ColorSync interference
+- **Multi-page TIFF support** — Print Current Page and Print All Pages correctly extract and send individual frames from multi-page charts
+- **Printer reachability check** — detects offline printers before submitting a job and shows a clear error dialog
 - **Clear Print Queue** button and stuck-job pre-print detection — cancels held or aborted jobs before submitting a new one
 - **AirPrint driver detection** in the Print tab — identifies when no configurable options are available and explains how to reinstall the printer with a native PPD driver
+- **Zoomable TIFF preview** panel on every tab (labelled CHART PREVIEW / PRINT PREVIEW) — live view of the generated chart updates as parameters change
 - **Spectral filter type** option in Measure tab (`-F` flag) — override the measurement condition (M0 / M1 / M2 / M3) for instruments that support it
 - Full `colprof` option set: illuminant (D50, D65, A, C, F5, F8, F10), observer (1931 2°, 1964 10°, 2015 variants), FWA compensation, gamut mapping source profiles, rendering intent overrides
 - Per-tab **Save as Defaults** and named user presets (Manual mode) for repeatable workflows

--- a/README.md
+++ b/README.md
@@ -70,16 +70,20 @@ ChromIQ walks you through five steps of RGB printer profiling:
 A4, A4 Landscape, A3, A3 Landscape, A2, US Letter, Letter Landscape, Legal, Tabloid (11×17)
 
 ### Key Capabilities
+- **ArgyllCMS auto-detection** at launch — searches the system PATH, Homebrew, MacPorts, and any versioned Argyll folder in `/Applications`. An **Auto-detect** button in Preferences re-runs detection on demand.
 - Empirical patch capacity database (measured with Argyll 3.5.0) for instant lookup without binary search
 - Separate patch counts for charts with and without the left clip border (`-L` flag)
 - Double-density mode for ColorMunki/i1Studio with measuring rig (`-h` flag)
 - Live TIFF preview of the generated test chart
-- Direct TIFF printing via CUPS — color management forced off, no ColorSync interference, no PostScript conversion
+- Direct TIFF printing via CUPS — color management forced off automatically, no manual option selection required, no ColorSync interference
+- **Clear Print Queue** button and stuck-job pre-print detection — cancels held or aborted jobs before submitting a new one
+- **AirPrint driver detection** in the Print tab — identifies when no configurable options are available and explains how to reinstall the printer with a native PPD driver
+- **Spectral filter type** option in Measure tab (`-F` flag) — override the measurement condition (M0 / M1 / M2 / M3) for instruments that support it
 - Full `colprof` option set: illuminant (D50, D65, A, C, F5, F8, F10), observer (1931 2°, 1964 10°, 2015 variants), FWA compensation, gamut mapping source profiles, rendering intent overrides
 - Per-tab **Save as Defaults** and named user presets (Manual mode) for repeatable workflows
 - Automatic session naming based on printer, paper, media type, instrument, and timestamp
+- **Update checker** — silent background check on launch; manual check available in Preferences
 - Settings persist between sessions via `QSettings`
-- Built-in ArgyllCMS binary tester and direct download link detection for your platform
 
 ---
 
@@ -87,7 +91,7 @@ A4, A4 Landscape, A3, A3 Landscape, A2, US Letter, Letter Landscape, Legal, Tabl
 
 ### System
 - macOS 13 Ventura or later (Apple Silicon and Intel supported)
-- [ArgyllCMS 3.5.0](https://www.argyllcms.com/downloaddev.html) — binaries must be installed at `/Applications/Argyll/bin` (configurable in Preferences)
+- [ArgyllCMS 3.5.0](https://www.argyllcms.com/downloaddev.html) — ChromIQ auto-detects ArgyllCMS at launch, scanning the system PATH, Homebrew, MacPorts, and any versioned Argyll folder in `/Applications`. The path can be overridden or re-detected from Preferences.
 
 ### To run from source
 - Python 3.12 or later
@@ -134,9 +138,9 @@ Copy `dist/ChromIQ.app` to `/Applications` and launch like any other macOS app. 
 ## Usage
 
 ### First-time setup
-1. Install ArgyllCMS and note the path to its `bin` folder (default: `/Applications/Argyll/bin`)
-2. Open ChromIQ → **ChromIQ ▸ Preferences** (or ⌘,) and verify the binary path
-3. Click **Test binaries** to confirm `targen`, `printtarg`, `chartread`, and `colprof` are found
+1. Install ArgyllCMS — download from [argyllcms.com](https://www.argyllcms.com/downloadmac.html), extract the archive, and move the folder to `/Applications`
+2. Launch ChromIQ — it auto-detects ArgyllCMS and configures itself. If detection fails, a setup guide opens with instructions.
+3. (Optional) Open **Preferences** (⌘,) → click **Auto-detect** to re-run detection, or browse to the `bin` folder manually, then **Test binaries** to confirm
 
 ### Step 1 — Create Chart
 - Choose **Guided** or **Manual** mode
@@ -178,11 +182,15 @@ ChromIQ/
 ├── requirements.txt
 ├── assets/                    # App icons and UI images
 ├── core/
+│   ├── argyll_detect.py       # ArgyllCMS auto-detection (PATH, Homebrew, /Applications scan)
 │   ├── argyll_runner.py       # QProcess wrapper for ArgyllCMS tools
 │   ├── file_manager.py        # Working folder and target name management
-│   ├── logger.py              # Rotating file logger (~ChromIQ/chromiq.log)
+│   ├── logger.py              # Rotating file logger (~Library/Logs/ChromIQ/chromiq.log)
 │   ├── resource_path.py       # Asset path resolution for dev + frozen bundles
-│   └── settings.py            # QSettings wrapper with typed defaults
+│   ├── settings.py            # QSettings wrapper with typed defaults
+│   ├── strip_utils.py         # Strip label parsing and TIFF zone detection
+│   ├── updater.py             # Background update checker (GitHub releases API)
+│   └── version.py             # Application version constant
 ├── data/
 │   ├── parameters.yaml        # All targen/printtarg/colprof flags + tooltips
 │   └── patch_db.py            # Empirical per-sheet patch capacity database
@@ -192,6 +200,7 @@ ChromIQ/
 │   ├── styles.py              # Fusion dark-theme QSS stylesheet
 │   ├── tiff_preview.py        # Zoomable TIFF viewer widget
 │   ├── tooltip_button.py      # ? icon with popover tooltip
+│   ├── tab_header.py          # Per-tab workflow header widget (step indicator + headline)
 │   ├── widgets.py             # Shared widget helpers (browse buttons, etc.)
 │   ├── dialogs/
 │   │   └── settings_dialog.py # Preferences dialog
@@ -269,13 +278,13 @@ Save the file and restart ChromIQ — the new parameter appears automatically in
 
 - **Measurement (Step 3):** Some spectrophotometer models may require additional calibration steps not yet surfaced in the UI.
 - **Advanced color science (Step 4):** FWA compensation and custom gamut mapping intents cover a wide range of instrument/paper combinations — edge cases may exist depending on your specific hardware and media.
-- **macOS only:** ChromIQ is developed and tested exclusively on macOS. The profile installation path (`~/Library/ColorSync/Profiles/`) and certain system integrations (dark title bar, macOS keychain) are macOS-specific. There are no plans for Windows or Linux support at this time.
+- **macOS only:** ChromIQ is developed and tested exclusively on macOS. The profile installation path (`~/Library/ColorSync/Profiles/`) and certain system integrations (dark title bar, macOS keychain) are macOS-specific. There are no plans for Windows or Linux support at this time. If you need a simple Windows or Linux option for printer profiling, try [Argyll_Printer_Profiler scripts](https://soul-traveller.github.io/Argyll_Printer_Profiler/) by Knut Georg Larsson.
 
 ---
 
 ## Log File
 
-ChromIQ writes a rotating log to `~/ChromIQ/chromiq.log` (max 2 MB, 3 backups). All ArgyllCMS commands and their full argument lists are recorded here at `INFO` level, which is useful for debugging unexpected behaviour.
+ChromIQ writes a rotating log to `~/Library/Logs/ChromIQ/chromiq.log` (max 2 MB, 3 backups). All ArgyllCMS commands and their full argument lists are recorded here at `INFO` level, which is useful for debugging unexpected behaviour.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ChromIQ walks you through five steps of RGB printer profiling:
 | `SS` | X-Rite SpectroScan (flatbed XY) |
 
 ### Paper Size Support
-A4, A4 Landscape, A3, A3 Landscape, A2, US Letter, Letter Landscape, Legal, Tabloid (11×17)
+A2, A3+, A3, A4, Tabloid (11×17), Legal, Letter, and landscape variants of each — plus photo formats (8×10", 5×7", 4×6") and fully custom dimensions (width × height in mm)
 
 ### Key Capabilities
 - **ArgyllCMS auto-detection** at launch — searches the system PATH, Homebrew, MacPorts, and any versioned Argyll folder in `/Applications`. An **Auto-detect** button in Preferences re-runs detection on demand.
@@ -75,12 +75,15 @@ A4, A4 Landscape, A3, A3 Landscape, A2, US Letter, Letter Landscape, Legal, Tabl
 - Separate patch counts for charts with and without the left clip border (`-L` flag)
 - Double-density mode for ColorMunki/i1Studio with measuring rig (`-h` flag)
 - Live TIFF preview of the generated test chart
-- Direct TIFF printing via CUPS — color management forced off automatically, no manual option selection required, no ColorSync interference
+- **PostScript Level 2/3 printing pipeline** — generates a device-dependent PS document (`/DeviceRGB`, `/DeviceCMYK`, `/DeviceN`) with `%cupsJobTicket: cups-disable-cmm`, ensuring zero colour transforms between the app and the printer
+- **CMYK and multi-channel (DeviceN) target support** — 4-channel CMYK and 5–17 channel extended-gamut targets (e.g. CMYK + LC LM) print correctly without colour channel corruption
+- **16-bit TIFF printing** via PostScript Level 3 for printers and RIPs with a true 16-bit pipeline (`printtarg -T300`)
+- **Automatic TIFF fallback** for AirPrint/driverless printers that reject PostScript — retries with colour-space-aware CUPS raster options, bypassing ColorSync without requiring PostScript support
 - **Multi-page TIFF support** — Print Current Page and Print All Pages correctly extract and send individual frames from multi-page charts
 - **Printer reachability check** — detects offline printers before submitting a job and shows a clear error dialog
 - **Clear Print Queue** button and stuck-job pre-print detection — cancels held or aborted jobs before submitting a new one
 - **AirPrint driver detection** in the Print tab — identifies when no configurable options are available and explains how to reinstall the printer with a native PPD driver
-- **Zoomable TIFF preview** panel on every tab (labelled CHART PREVIEW / PRINT PREVIEW) — live view of the generated chart updates as parameters change
+- **Zoomable TIFF preview** with full multi-channel support — displays RGB, CMYK, and extended-gamut TIFFs (up to 8 inks) with ICC-accurate colour conversion (US Web Coated SWOP v2); LZW-compressed files supported
 - **Spectral filter type** option in Measure tab (`-F` flag) — override the measurement condition (M0 / M1 / M2 / M3) for instruments that support it
 - Full `colprof` option set: illuminant (D50, D65, A, C, F5, F8, F10), observer (1931 2°, 1964 10°, 2015 variants), FWA compensation, gamut mapping source profiles, rendering intent overrides
 - Per-tab **Save as Defaults** and named user presets (Manual mode) for repeatable workflows
@@ -154,8 +157,8 @@ Copy `dist/ChromIQ.app` to `/Applications` and launch like any other macOS app. 
 ### Step 2 — Print Chart
 - Select your printer from the dropdown (click ↺ to refresh the list)
 - Configure paper slot, media type, and print quality if needed
-- Use **No Color Adjustment** in your printer driver to bypass color management when printing
-- Click **Print Page X** for each page of the chart
+- Click **Print Page X** for each page of the chart — color management is disabled automatically via the PostScript pipeline; no driver settings need changing
+- For AirPrint/driverless printers, ChromIQ falls back to TIFF automatically if the printer rejects PostScript
 
 ### Step 3 — Measure Chart
 - The `.ti2` file from Step 1 is loaded automatically
@@ -217,7 +220,7 @@ ChromIQ/
     ├── chart_creator.py       # targen + printtarg orchestration
     ├── cups_printer.py        # lp command wrapper
     ├── measure_manager.py     # chartread orchestration
-    ├── postscript_generator.py  # PostScript generation — internal infrastructure, not used in current workflow
+    ├── postscript_generator.py  # PostScript Level 2/3 document generation for the print pipeline
     ├── print_manager.py       # Printer enumeration (lpstat)
     ├── profile_builder.py     # colprof orchestration
     └── profcheck_runner.py    # profcheck orchestration, ΔE parsing, quality grading, refinement guidance

--- a/ui/dialogs/settings_dialog.py
+++ b/ui/dialogs/settings_dialog.py
@@ -22,6 +22,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from core.argyll_detect import find_argyll_bin_path
 from core.logger import get_logger
 from core.updater import UpdateChecker, _RELEASES_PAGE
 from core.version import APP_VERSION
@@ -79,9 +80,12 @@ class SettingsDialog(QDialog):
         btn_row = QHBoxLayout()
         test_btn = QPushButton("Test binaries", self)
         test_btn.clicked.connect(self._test_argyll)
+        detect_btn = QPushButton("Auto-detect", self)
+        detect_btn.clicked.connect(self._auto_detect)
         dl_btn = QPushButton("Download latest ArgyllCMS…", self)
         dl_btn.clicked.connect(self._open_argyll_download)
         btn_row.addWidget(test_btn)
+        btn_row.addWidget(detect_btn)
         btn_row.addWidget(dl_btn)
         btn_row.addStretch()
         ag.addLayout(btn_row)
@@ -204,6 +208,20 @@ class SettingsDialog(QDialog):
         )
         if d:
             self._folder_edit.setText(d)
+
+    def _auto_detect(self) -> None:
+        detected = find_argyll_bin_path()
+        if detected:
+            self._argyll_edit.setText(str(detected))
+            self._argyll_status.setStyleSheet("color: #4caf50;")
+            self._argyll_status.setText(f"Auto-detected at {detected}")
+        else:
+            self._argyll_status.setStyleSheet("color: #ff5252;")
+            self._argyll_status.setText(
+                "ArgyllCMS not found in any known location. "
+                "Install it or set the path manually."
+            )
+        log.info("ArgyllCMS auto-detect: %s", detected)
 
     def _test_argyll(self) -> None:
         bin_dir = Path(self._argyll_edit.text().strip())


### PR DESCRIPTION
## Code change\n- **Preferences dialog**: new **Auto-detect** button next to *Test binaries*. Calls `find_argyll_bin_path()` and fills the path field with the result (or shows a clear error). The detection already ran silently at startup — this makes it user-triggerable without restarting the app.\n\n## README updates\n- **Requirements**: replace static `/Applications/Argyll/bin` path with description of auto-detection (PATH, Homebrew, MacPorts, /Applications scan)\n- **First-time setup**: reflects the auto-detection flow; mentions Auto-detect button in Preferences\n- **Key Capabilities**: added auto-detection, Clear Print Queue + stuck-job pre-print check, AirPrint driver detection, spectral filter option (`-F`), update checker — all missing from the previous README\n- **Project structure**: added `argyll_detect.py`, `strip_utils.py`, `updater.py`, `version.py`, `tab_header.py` (all existed in code but were absent from the listing)\n- **Log file path**: corrected from `~/ChromIQ/chromiq.log` → `~/Library/Logs/ChromIQ/chromiq.log` (moved in v1.2.0)\n- **Known Issues**: added Knut's requested note — *"If you need a simple Windows or Linux option for printer profiling, try Argyll_Printer_Profiler scripts by Knut Georg Larsson"* with link to the GitHub Pages user guide

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8J7QEf83En2yk3jDM6cFi)_