### PR TITLE
README: fix Python dependencies and complete project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ A2, A3+, A3, A4, Tabloid (11×17), Legal, Letter, and landscape variants of each
 PyQt6 >= 6.11.0
 Pillow >= 10.0.0
 PyYAML >= 6.0
+pycups >= 2.0.1
+certifi >= 2024.0.0
+tifffile >= 2024.0.0
+numpy >= 1.24.0
+imagecodecs >= 2024.0.0
 ```
 
 ---
@@ -206,9 +211,15 @@ ChromIQ/
 │   ├── main_window.py         # Top-level window, tab container, status bar
 │   ├── parameter_widget.py    # Auto-generated flag widgets from parameters.yaml
 │   ├── styles.py              # Fusion dark-theme QSS stylesheet
-│   ├── tiff_preview.py        # Zoomable TIFF viewer widget
+│   ├── tiff_preview.py        # Zoomable multi-channel TIFF viewer widget
 │   ├── tooltip_button.py      # ? icon with popover tooltip
 │   ├── tab_header.py          # Per-tab workflow header widget (step indicator + headline)
+│   ├── masthead_header.py     # Gradient masthead banner at the top of the window
+│   ├── gradient_overlay.py    # Accent-coloured gradient wash on tab control panels
+│   ├── spectrum_tab_bar.py    # Per-tab coloured tab bar
+│   ├── spectrum_progress.py   # Animated five-segment spectrum progress bar
+│   ├── scan_highlighter.py    # Strip highlight overlay during chartread measurement
+│   ├── ti2_loader.py          # .ti2 file loading and cross-tab population logic
 │   ├── widgets.py             # Shared widget helpers (browse buttons, etc.)
 │   ├── dialogs/
 │   │   └── settings_dialog.py # Preferences dialog

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ A2, A3+, A3, A4, Tabloid (11×17), Legal, Letter, and landscape variants of each
 - Full `colprof` option set: illuminant (D50, D65, A, C, F5, F8, F10), observer (1931 2°, 1964 10°, 2015 variants), FWA compensation, gamut mapping source profiles, rendering intent overrides
 - Per-tab **Save as Defaults** and named user presets (Manual mode) for repeatable workflows
 - Automatic session naming based on printer, paper, media type, instrument, and timestamp
+- **Optional calibration workflow** (`printcal → applycal`) — enabled via Preferences → Behaviour → "Enable calibration options" (off by default). When active: guided panels are hidden, Tab 4 becomes "Calibration & Profiling" with three modules (Create Calibration File, Build Profile, Apply Calibration), and measurements whose filename starts with `cal_` are automatically routed to the calibration module
+- **Session restore** — "Restore last session on launch" in Preferences reloads the previously active project files (`.ti2`, `.ti3`, `.icc`) on startup
 - **Update checker** — silent background check on launch; manual check available in Preferences
 - Settings persist between sessions via `QSettings`
 
@@ -222,6 +224,8 @@ ChromIQ/
     ├── measure_manager.py     # chartread orchestration
     ├── postscript_generator.py  # PostScript Level 2/3 document generation for the print pipeline
     ├── print_manager.py       # Printer enumeration (lpstat)
+    ├── printcal_runner.py     # printcal orchestration (calibration curve generation)
+    ├── applycal_runner.py     # applycal orchestration (bake/remove/check calibration on ICC)
     ├── profile_builder.py     # colprof orchestration
     └── profcheck_runner.py    # profcheck orchestration, ΔE parsing, quality grading, refinement guidance
 ```
@@ -238,6 +242,14 @@ All settings are stored via `QSettings` (macOS: `~/Library/Preferences/ChromIQ.C
 |---------|---------|-------------|
 | ArgyllCMS bin path | `/Applications/Argyll/bin` | Directory containing the ArgyllCMS executables |
 | Output folder | `~/ChromIQ/` | Root folder for all chart/profile sessions |
+
+**Behaviour settings** (Preferences → Behaviour):
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Restore last active tab on launch | On | Re-opens on the tab that was active when the app was closed |
+| Restore last session on launch | Off | Reloads previously loaded files (`.ti2`, `.ti3`, `.icc`) on startup |
+| Enable calibration options | Off | Unlocks the full `printcal → applycal` calibration workflow |
 
 **Per-tab defaults** — every tab has a **Save as Defaults** button that persists the current parameter values for that step. Defaults are restored on the next launch.
 


### PR DESCRIPTION
Two gaps in the README found by comparing against the actual repo:\n\n**Python dependencies** — README listed only 3 packages; `requirements.txt` has 9. Added the 5 missing runtime dependencies: `pycups`, `certifi`, `tifffile`, `numpy`, `imagecodecs`.\n\n**Project structure** — 6 `ui/` modules existed in the codebase but were absent from the listing: `gradient_overlay`, `masthead_header`, `scan_highlighter`, `spectrum_progress`, `spectrum_tab_bar`, `ti2_loader`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8J7QEf83En2yk3jDM6cFi)_