### PR TITLE
Add downloads badge to README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <img alt="Version" src="https://img.shields.io/badge/version-3.8.2-7c5cff">
+  <img alt="Downloads" src="https://img.shields.io/github/downloads/itsab1989/ChromIQ/total?label=downloads&color=212121">
   <img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%C2%B7%20Windows%20%C2%B7%20Linux-2a9d8f">
   <img alt="License" src="https://img.shields.io/badge/license-GPLv3-blue">
 </p>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 <p align="center">
   <img alt="Version" src="https://img.shields.io/badge/version-3.8.2-7c5cff">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/itsab1989/ChromIQ/total?label=downloads&color=212121">
-  <img alt="Clones" src="https://img.shields.io/badge/clones-6851-2196F3">
   <img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%C2%B7%20Windows%20%C2%B7%20Linux-2a9d8f">
   <img alt="License" src="https://img.shields.io/badge/license-GPLv3-blue">
 </p>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p align="center">
   <img alt="Version" src="https://img.shields.io/badge/version-3.8.2-7c5cff">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/itsab1989/ChromIQ/total?label=downloads&color=212121">
+  <img alt="Clones" src="https://img.shields.io/badge/clones-6851-2196F3">
   <img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%C2%B7%20Windows%20%C2%B7%20Linux-2a9d8f">
   <img alt="License" src="https://img.shields.io/badge/license-GPLv3-blue">
 </p>


### PR DESCRIPTION
Adds a **Downloads** badge to the centered README banner, styled to match the GitHub traffic dashboard.

- Live shields.io `github/downloads/itsab1989/ChromIQ/total` badge — cumulative release-asset downloads, auto-updating — color `212121`.

(A static clones badge was tried and dropped: GitHub clone counts come from the auth-only Traffic API with no public live endpoint, so it would go stale.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)