### PR TITLE
Use traffic-dashboard endpoint for downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <img alt="Version" src="https://img.shields.io/badge/version-3.8.3-7c5cff">
-  <img alt="Downloads" src="https://img.shields.io/github/downloads/itsab1989/ChromIQ/total?label=downloads&color=212121">
+  <img alt="Downloads" src="https://img.shields.io/endpoint?url=https://itsab1989.github.io/github-traffic-downloads-dashboard/assets/badges/itsab1989_ChromIQ-downloads.json">
   <img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%C2%B7%20Windows%20%C2%B7%20Linux-2a9d8f">
   <img alt="License" src="https://img.shields.io/badge/license-GPLv3-blue">
 </p>


### PR DESCRIPTION
Swaps the README downloads badge from shields' built-in `github/downloads` endpoint to the traffic dashboard's published **endpoint badge**.

**Why:** the built-in badge only sums the most recent 100 releases, so it under-counted ChromIQ (~196 releases) by ~27% — 557 shown vs. a true 763. The dashboard paginates every release and publishes the accurate lifetime total, refreshed hourly.

```
https://img.shields.io/endpoint?url=https://itsab1989.github.io/github-traffic-downloads-dashboard/assets/badges/itsab1989_ChromIQ-downloads.json
```

> ⚠️ **Merge order:** depends on github-traffic-dashboard PR #8. The endpoint JSON only goes live on GitHub Pages once that PR is merged to the default branch and Pages redeploys. Merge #8 first, otherwise this badge renders as "inaccessible" until the JSON is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)