### PR TITLE
Tools: busy indicator with step + elapsed display; printer mode stops offering averaging

### DIFF
--- a/data/i18n/de.json
+++ b/data/i18n/de.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ Kein Chart-Layout gefunden: Neben dem Testchart „{name}“ liegt keine .channels.json mit verwendbarer Geometrie. ChromIQ schreibt diese Datei beim Erstellen eines Testcharts — wähle das Testchart in seinem ursprünglichen Ordner (oder kopiere die .channels.json mit).",
   "one scan per page — {k} of {n} picked": "ein Scan pro Seite — {k} von {n} gewählt",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Nicht jedes Messfeld dieser Seite konnte gelesen werden — vermutlich sitzt das Raster nicht richtig. Prüfe das Diagnosebild (falls gespeichert), richte das Raster auf dem Scan dieser Seite neu aus und erstelle das Profil erneut; ein Profil aus einer unvollständigen Lesung wäre falsch.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ Dieser Scan konnte für die Vorschau nicht dekodiert werden, daher lässt sich das Raster nicht darauf ausrichten. Speichere den Scan als 8-Bit-TIFF (oder PNG) neu und wähle ihn erneut."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ Dieser Scan konnte für die Vorschau nicht dekodiert werden, daher lässt sich das Raster nicht darauf ausrichten. Speichere den Scan als 8-Bit-TIFF (oder PNG) neu und wähle ihn erneut.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Hinweis: Für ein Druckerprofil wird nicht gemittelt — nur der erste Scan jeder Seite wird gelesen.",
+  "Step {k} of {n}": "Schritt {k} von {n}",
+  "Working…": "Arbeitet …",
+  "{n} s — still working": "{n} s — arbeitet noch"
 }

--- a/data/i18n/es.json
+++ b/data/i18n/es.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/fr.json
+++ b/data/i18n/fr.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/it.json
+++ b/data/i18n/it.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/ja.json
+++ b/data/i18n/ja.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/nl.json
+++ b/data/i18n/nl.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/no.json
+++ b/data/i18n/no.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/pl.json
+++ b/data/i18n/pl.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/pt.json
+++ b/data/i18n/pt.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/ru.json
+++ b/data/i18n/ru.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/sv.json
+++ b/data/i18n/sv.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/data/i18n/zh_CN.json
+++ b/data/i18n/zh_CN.json
@@ -2423,5 +2423,9 @@
   "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).": "⚠ No chart layout found: the chart “{name}” has no .channels.json with usable geometry next to it. ChromIQ writes that sidecar when it creates a chart — pick the chart inside its original folder (or copy the .channels.json along with it).",
   "one scan per page — {k} of {n} picked": "one scan per page — {k} of {n} picked",
   "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.": "⚠ Not every patch on this page could be read — the grid placement is probably off. Check the diagnostic image (if saved), realign the grid on this page's scan and build again; a profile from a partial read will be wrong.",
-  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again."
+  "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.": "⚠ This scan couldn't be decoded for the preview, so the grid can't be aligned on it. Re-save the scan as an 8-bit TIFF (or PNG) and pick it again.",
+  "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
+  "Step {k} of {n}": "Step {k} of {n}",
+  "Working…": "Working…",
+  "{n} s — still working": "{n} s — still working"
 }

--- a/tests/test_scanin_dialog.py
+++ b/tests/test_scanin_dialog.py
@@ -753,3 +753,60 @@ def test_printer_checkbox_sits_above_chart_row(_app):
         assert dlg._page_widget.parent() is not None
     finally:
         dlg.deleteLater()
+
+
+def test_printer_mode_hides_averaging_and_says_first_scan_wins(_app, tmp_path):
+    """Printer mode reads one scan per page — the averaging affordances hide
+    (extra shots were silently ignored before), and a run with leftover extra
+    shots says so in the log (Knut's question)."""
+    from pathlib import Path as P
+    dlg = _dialog(_app)
+    try:
+        dlg._ti3 = tmp_path / "mychart.ti2"
+        (tmp_path / "mychart.ti2").write_text("CTI2\n")
+        dlg._layout = {"patches": [{"page": 0}]}
+        dlg._pages = [0]
+        shots = dlg._page_shots(0)
+        shots.clear()
+        for k in (1, 2):
+            (tmp_path / f"s{k}.tif").write_bytes(b"II*\0")
+            shots.append({"path": tmp_path / f"s{k}.tif",
+                          "corners": [(0, 0), (9, 0), (9, 9), (0, 9)]})
+        dlg._printer_cb.setChecked(True)
+        assert not dlg._add_shot_btn.isVisibleTo(dlg)
+        assert not dlg._avg_row_w.isVisibleTo(dlg)
+        dlg._printer_scan_profile = tmp_path / "scanner.icc"
+        dlg._run_job = lambda i: None
+        dlg._execute_printer(tmp_path / "mychart", 0.9)
+        assert "first scan of each page" in dlg._log.toPlainText()
+        # Scanner mode gets the button back.
+        dlg._printer_cb.setChecked(False)
+        assert dlg._add_shot_btn.isVisibleTo(dlg)
+    finally:
+        dlg.deleteLater()
+
+
+def test_busy_bar_shows_steps_and_stops_on_finish(_app, tmp_path):
+    """The busy bar (Knut: 'nothing moves for a long time') names the running
+    step and disappears when the run ends."""
+    from pathlib import Path as P
+    dlg = _dialog(_app)
+    try:
+        dlg._ti3 = P("/tmp/proj/mychart.ti3")
+        dlg._layout = {"patches": [{"page": 0}]}
+        dlg._pages = [0]
+        shots = dlg._page_shots(0)
+        shots.clear()
+        shots.append({"path": P("/tmp/proj/s1.tif"),
+                      "corners": [(0, 0), (9, 0), (9, 9), (0, 9)]})
+        dlg._set_busy(True)
+        assert dlg._busy_bar.isVisibleTo(dlg)
+        scan_runs = []
+        dlg._scanin.run = lambda params, on_line, on_finish: scan_runs.append(params)
+        dlg._execute()
+        assert "Step 1 of 2" in dlg._busy_bar._label
+        dlg._finish(True)
+        assert not dlg._busy_bar.isVisibleTo(dlg)
+        assert not dlg._busy_tick.isActive()
+    finally:
+        dlg.deleteLater()

--- a/ui/dialogs/scanin_dialog.py
+++ b/ui/dialogs/scanin_dialog.py
@@ -712,9 +712,15 @@ class ScannerProfileDialog(_ToolDialogBase):
         self._shot_combo.setCurrentIndex(min(self._shot_idx, len(shots) - 1))
         self._shot_combo.blockSignals(False)
         multi = len(shots) > 1
-        self._shot_combo.setVisible(multi)
+        printer = self._printer_mode()
+        # Printer mode reads ONE scan per page (the pages accumulate into a
+        # single .ti3) — extra shots were silently ignored, so don't offer to
+        # add them there (Knut's question; per-page averaging for printer mode
+        # would be its own feature).
+        self._add_shot_btn.setVisible(not printer)
+        self._shot_combo.setVisible(multi and not printer)
         self._remove_shot_btn.setVisible(multi)
-        self._avg_row_w.setVisible(multi)
+        self._avg_row_w.setVisible(multi and not printer)
         if len(self._pages) > 1:
             done = sum(1 for pg in self._pages
                        if any(sh["path"] for sh in self._page_shots(pg)))
@@ -1273,6 +1279,7 @@ class ScannerProfileDialog(_ToolDialogBase):
         self._printer_box.setVisible(checked)
         # The Chart-geometry (.cht) row only matters in printer mode (#105).
         self._byo_row_w.setVisible(checked)
+        self._refresh_shot_bar()   # averaging affordances hide in printer mode
         # In printer mode the chart's .ti2 is enough (no measurement needed), so the
         # picker asks for the chart you printed rather than a measured .ti3.
         self._chart_label.setText(
@@ -1825,8 +1832,11 @@ class ScannerProfileDialog(_ToolDialogBase):
         if i >= len(self._jobs):
             return
         job = self._jobs[i]
+        total = len(self._jobs)
+        step = tr("Step {k} of {n}").format(k=i + 1, n=total)
         if job["kind"] == "scanin":
             self._log.appendPlainText(job["label"])
+            self._set_busy_note(f"{step} — {job['label']}", fraction=i / total)
 
             unfilled = []
 
@@ -1857,8 +1867,9 @@ class ScannerProfileDialog(_ToolDialogBase):
 
             self._scanin.run(job["params"], on_line=_watch, on_finish=_done)
         elif job["kind"] == "average":
-            self._log.appendPlainText(
-                tr("Averaging {n} scans of this page…").format(n=len(job["ti3s"])))
+            _avg = tr("Averaging {n} scans of this page…").format(n=len(job["ti3s"]))
+            self._log.appendPlainText(_avg)
+            self._set_busy_note(f"{step} — {_avg}", fraction=i / total)
             try:
                 average_scanner_ti3(job["ti3s"], job["out"], method=job["method"])
             except (Ti3AverageError, OSError) as exc:
@@ -1867,8 +1878,14 @@ class ScannerProfileDialog(_ToolDialogBase):
                 return
             self._run_job(i + 1)
         elif job["kind"] == "colprof_printer":
+            self._set_busy_note(
+                f"{step} — " + tr("Building the printer profile…"),
+                fraction=i / total)
             self._build_printer_profile(job["pbase"], job["base"])
         else:
+            self._set_busy_note(
+                f"{step} — " + tr("Building the scanner profile…"),
+                fraction=i / total)
             self._build_profile(job["ti3s"], job["base"])
 
     def _execute_printer(self, base: Path, frac: float) -> None:
@@ -1898,6 +1915,11 @@ class ScannerProfileDialog(_ToolDialogBase):
             self._finish(False)
             return
         self._jobs = []
+        if any(sum(1 for sh in self._page_shots(pg) if sh["path"]) > 1
+               for pg in self._pages):
+            self._log.appendPlainText(tr(
+                "Note: averaging isn't used for a printer profile — only the "
+                "first scan of each page is read."))
         first_page = True
         for pg in self._pages:
             orig_cht, _ = self._files_for_page(pg, base)

--- a/ui/dialogs/tools_dialogs.py
+++ b/ui/dialogs/tools_dialogs.py
@@ -21,7 +21,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QGuiApplication
 from PyQt6.QtWidgets import (
     QButtonGroup,
@@ -45,6 +45,7 @@ from PyQt6.QtWidgets import (
 from core.i18n import tr
 from core.logger import get_logger
 from ui.fade_scroll import FadeScrollArea
+from ui.spectrum_progress import SpectrumSegmentsBar
 from ui.styles import BG_INPUT, BORDER, SPEC_GREEN, SPEC_MAGENTA, SPEC_VIOLET, TEXT_MAIN
 from ui.theme import resolve_mode
 from ui.tab_header import dialog_masthead
@@ -289,6 +290,18 @@ class _ToolDialogBase(QDialog):
             self._scroll = None
             inner.addLayout(self._content)
 
+        # Busy indicator: an animated spectrum bar + ticking elapsed time above
+        # the log, shown while a run is under way — external tools can stay
+        # silent for a long time and the window looked frozen (Knut).
+        self._busy_bar = SpectrumSegmentsBar(self)
+        self._busy_bar.setVisible(False)
+        inner.addWidget(self._busy_bar)
+        self._busy_note = ""
+        self._busy_started = 0.0
+        self._busy_tick = QTimer(self)
+        self._busy_tick.setInterval(1000)
+        self._busy_tick.timeout.connect(self._update_busy_label)
+
         # Log / status area
         self._log = QPlainTextEdit(self)
         self._log.setReadOnly(True)
@@ -429,6 +442,35 @@ class _ToolDialogBase(QDialog):
     def _set_busy(self, busy: bool) -> None:
         self._run_btn.setEnabled(not busy and self._can_run())
         self._close_btn.setEnabled(not busy)
+        self._busy_bar.setVisible(busy)
+        if busy:
+            import time
+            self._busy_started = time.monotonic()
+            self._busy_bar.reset()
+            self._update_busy_label()
+            self._busy_bar.start()
+            self._busy_tick.start()
+            self.setCursor(Qt.CursorShape.BusyCursor)
+        else:
+            self._busy_tick.stop()
+            self._busy_bar.stop()
+            self._busy_note = ""
+            self.unsetCursor()
+
+    def _set_busy_note(self, note: str, fraction: float | None = None) -> None:
+        """Name the running step (and optionally its 0..1 position in the whole
+        run) on the busy bar — e.g. "Step 2 of 6 — Reading page 2…"."""
+        self._busy_note = note
+        if fraction is not None:
+            self._busy_bar.set_value(fraction)
+        self._update_busy_label()
+
+    def _update_busy_label(self) -> None:
+        import time
+        secs = int(time.monotonic() - self._busy_started)
+        self._busy_bar.set_label(
+            self._busy_note or tr("Working…"),
+            tr("{n} s — still working").format(n=secs) if secs >= 3 else "")
 
     def _finish(self, success: bool) -> None:
         self._set_busy(False)


### PR DESCRIPTION
Two items from Knut's latest feedback round (relayed from the forum).

## "Nothing moves for a long time"

scanin on 34-MP scans and colprof both go silent for long stretches, so the scanner tool looked frozen mid-build. Every Tools dialog now shows the **spectrum busy bar** (the same widget Build Profile uses) above its status log while a run is under way:

- pulsing segments plus a ticking **"{n} s — still working"** elapsed readout (the seconds ticking is the visible life-sign during silent stretches),
- a **busy mouse cursor** over the window,
- in the scanner tool, the current step by name — **"Step 2 of 6 — Reading page 2 for the printer profile…"** — with the bar filling across the job list.

Implemented in `_ToolDialogBase` (hooked into the existing `_set_busy`/`_finish` bracket), so every tool gets it; the scanner dialog feeds the step notes.

## "What happens with Add another scan to average in printer mode?"

Answer: nothing good — printer mode reads **one scan per page** (all pages accumulate into a single `.ti3` via `scanin -c/-ca`), so extra shots were **silently ignored**. Now:

- the averaging affordances ("＋ Add another scan to average", the scan switcher, the method row) hide in printer mode,
- a run that still carries leftover extra shots logs "averaging isn't used for a printer profile — only the first scan of each page is read".

True per-page averaging for printer profiles (scan each page N times) would need per-shot accumulation targets — a separate feature if Knut wants it.

## Tests

Busy-bar lifecycle (visible + step label during a run, hidden + ticker stopped on finish) and the printer-mode averaging guard (buttons hidden, honest log note, buttons return in scanner mode). Full suite: **1614 passed, 2 skipped**. i18n synced (German translated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)