### PR TITLE
Busy bar: scanner tool only, always visible, animated only while running

### DIFF
--- a/data/i18n/de.json
+++ b/data/i18n/de.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Hinweis: Für ein Druckerprofil wird nicht gemittelt — nur der erste Scan jeder Seite wird gelesen.",
   "Step {k} of {n}": "Schritt {k} von {n}",
   "Working…": "Arbeitet …",
-  "{n} s — still working": "{n} s — arbeitet noch"
+  "{n} s — still working": "{n} s — arbeitet noch",
+  "Ready": "Bereit"
 }

--- a/data/i18n/es.json
+++ b/data/i18n/es.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Listo"
 }

--- a/data/i18n/fr.json
+++ b/data/i18n/fr.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Prêt"
 }

--- a/data/i18n/it.json
+++ b/data/i18n/it.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Pronto"
 }

--- a/data/i18n/ja.json
+++ b/data/i18n/ja.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "準備完了"
 }

--- a/data/i18n/nl.json
+++ b/data/i18n/nl.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Gereed"
 }

--- a/data/i18n/no.json
+++ b/data/i18n/no.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Klar"
 }

--- a/data/i18n/pl.json
+++ b/data/i18n/pl.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Gotowe"
 }

--- a/data/i18n/pt.json
+++ b/data/i18n/pt.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Pronto"
 }

--- a/data/i18n/ru.json
+++ b/data/i18n/ru.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Готово"
 }

--- a/data/i18n/sv.json
+++ b/data/i18n/sv.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "Klar"
 }

--- a/data/i18n/zh_CN.json
+++ b/data/i18n/zh_CN.json
@@ -2427,5 +2427,6 @@
   "Note: averaging isn't used for a printer profile — only the first scan of each page is read.": "Note: averaging isn't used for a printer profile — only the first scan of each page is read.",
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
-  "{n} s — still working": "{n} s — still working"
+  "{n} s — still working": "{n} s — still working",
+  "Ready": "就绪"
 }

--- a/tests/test_scanin_dialog.py
+++ b/tests/test_scanin_dialog.py
@@ -786,12 +786,19 @@ def test_printer_mode_hides_averaging_and_says_first_scan_wins(_app, tmp_path):
         dlg.deleteLater()
 
 
-def test_busy_bar_shows_steps_and_stops_on_finish(_app, tmp_path):
-    """The busy bar (Knut: 'nothing moves for a long time') names the running
-    step and disappears when the run ends."""
+def test_busy_bar_always_visible_animated_only_while_running(_app, tmp_path):
+    """The busy bar (Knut: 'nothing moves for a long time') is a fixture of the
+    scanner tool like the Build Profile tab's bar: always visible, idle label
+    when nothing runs, step label + animation only during a run — and only this
+    tool opts in (the base default has no bar)."""
     from pathlib import Path as P
+    from ui.dialogs.tools_dialogs import _ToolDialogBase
+    assert _ToolDialogBase.BUSY_BAR_IDLE_LABEL is None   # other tools: no bar
     dlg = _dialog(_app)
     try:
+        assert dlg._busy_bar is not None
+        assert dlg._busy_bar.isVisibleTo(dlg)            # visible while idle
+        assert not dlg._busy_tick.isActive()             # …but not animated
         dlg._ti3 = P("/tmp/proj/mychart.ti3")
         dlg._layout = {"patches": [{"page": 0}]}
         dlg._pages = [0]
@@ -800,13 +807,14 @@ def test_busy_bar_shows_steps_and_stops_on_finish(_app, tmp_path):
         shots.append({"path": P("/tmp/proj/s1.tif"),
                       "corners": [(0, 0), (9, 0), (9, 9), (0, 9)]})
         dlg._set_busy(True)
-        assert dlg._busy_bar.isVisibleTo(dlg)
+        assert dlg._busy_tick.isActive()                 # animating
         scan_runs = []
         dlg._scanin.run = lambda params, on_line, on_finish: scan_runs.append(params)
         dlg._execute()
         assert "Step 1 of 2" in dlg._busy_bar._label
         dlg._finish(True)
-        assert not dlg._busy_bar.isVisibleTo(dlg)
-        assert not dlg._busy_tick.isActive()
+        assert dlg._busy_bar.isVisibleTo(dlg)            # still visible…
+        assert not dlg._busy_tick.isActive()             # …but idle again
+        assert dlg._busy_bar._label == dlg.BUSY_BAR_IDLE_LABEL
     finally:
         dlg.deleteLater()

--- a/ui/dialogs/scanin_dialog.py
+++ b/ui/dialogs/scanin_dialog.py
@@ -170,6 +170,7 @@ class ScannerProfileDialog(_ToolDialogBase):
     EYEBROW     = tr("MEASURE · SCANNER / CAMERA PROFILE")
     ACCENT      = SPEC_GREEN
     RUN_LABEL   = tr("Build scanner or camera profile")
+    BUSY_BAR_IDLE_LABEL = tr("Ready")   # always-visible bar; animates while running
     MIN_WIDTH   = 760
     SCROLLABLE_CONTENT = True    # tall (mode toggle + inputs + marquee + averaging)
 

--- a/ui/dialogs/tools_dialogs.py
+++ b/ui/dialogs/tools_dialogs.py
@@ -225,6 +225,9 @@ class _ToolDialogBase(QDialog):
     RUN_LABEL: str  = tr("Run")
     MIN_WIDTH: int  = 620
     SCROLLABLE_CONTENT: bool = False   # tall dialogs opt in (scroll + edge fade)
+    # Set to a short idle label (e.g. tr("Ready")) to show an always-visible
+    # spectrum busy bar above the log, animated only while a run is under way.
+    BUSY_BAR_IDLE_LABEL: str | None = None
 
     def __init__(self, settings: "AppSettings", parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -290,12 +293,16 @@ class _ToolDialogBase(QDialog):
             self._scroll = None
             inner.addLayout(self._content)
 
-        # Busy indicator: an animated spectrum bar + ticking elapsed time above
-        # the log, shown while a run is under way — external tools can stay
-        # silent for a long time and the window looked frozen (Knut).
-        self._busy_bar = SpectrumSegmentsBar(self)
-        self._busy_bar.setVisible(False)
-        inner.addWidget(self._busy_bar)
+        # Busy indicator (opt-in via BUSY_BAR_IDLE_LABEL): an always-visible
+        # spectrum bar above the log, animated only while a run is under way —
+        # external tools can stay silent for a long time and the window looked
+        # frozen (Knut). Mirrors the Build Profile tab's bar.
+        self._busy_bar = None
+        if self.BUSY_BAR_IDLE_LABEL is not None:
+            self._busy_bar = SpectrumSegmentsBar(self)
+            self._busy_bar.set_label(self.BUSY_BAR_IDLE_LABEL, "")
+            self._busy_bar.set_value(0)
+            inner.addWidget(self._busy_bar)
         self._busy_note = ""
         self._busy_started = 0.0
         self._busy_tick = QTimer(self)
@@ -442,7 +449,8 @@ class _ToolDialogBase(QDialog):
     def _set_busy(self, busy: bool) -> None:
         self._run_btn.setEnabled(not busy and self._can_run())
         self._close_btn.setEnabled(not busy)
-        self._busy_bar.setVisible(busy)
+        if self._busy_bar is None:
+            return
         if busy:
             import time
             self._busy_started = time.monotonic()
@@ -455,12 +463,16 @@ class _ToolDialogBase(QDialog):
             self._busy_tick.stop()
             self._busy_bar.stop()
             self._busy_note = ""
+            self._busy_bar.set_value(0)
+            self._busy_bar.set_label(self.BUSY_BAR_IDLE_LABEL, "")
             self.unsetCursor()
 
     def _set_busy_note(self, note: str, fraction: float | None = None) -> None:
         """Name the running step (and optionally its 0..1 position in the whole
         run) on the busy bar — e.g. "Step 2 of 6 — Reading page 2…"."""
         self._busy_note = note
+        if self._busy_bar is None:
+            return
         if fraction is not None:
             self._busy_bar.set_value(fraction)
         self._update_busy_label()


### PR DESCRIPTION
Refines the beta.115 busy indicator per Basti's direction: like the Build Profile tab's bar, it is now an always-visible fixture of the scanner tool — "Ready" while idle, animated with the step name ("Step 2 of 6 — Reading page 2…"), ticking elapsed seconds and a busy cursor only while a run is under way. Other Tools dialogs no longer show it (the machinery stays in the base behind an opt-in `BUSY_BAR_IDLE_LABEL` class attribute). "Ready" translated in all 12 languages. Full suite: 1614 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)