### PR TITLE
BYO-cht printer profiling: correct grid geometry end-to-end (#108 round 2)

### DIFF
--- a/data/i18n/de.json
+++ b/data/i18n/de.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Schritt {k} von {n}",
   "Working…": "Arbeitet …",
   "{n} s — still working": "{n} s — arbeitet noch",
-  "Ready": "Bereit"
+  "Ready": "Bereit",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Ausrichtungsprüfung: {p}% der Messfelder wurden deutlich anders gelesen, als das Testchart dem Drucker vorgegeben hat (ΔE über 15). Vermutlich saß das Raster auf einem Scan falsch — oder ein Scan gehört nicht zu diesem Testchart. Prüfe die Diagnosebilder, bevor du diesem Profil vertraust."
 }

--- a/data/i18n/es.json
+++ b/data/i18n/es.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Listo"
+  "Ready": "Listo",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/fr.json
+++ b/data/i18n/fr.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Prêt"
+  "Ready": "Prêt",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/it.json
+++ b/data/i18n/it.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Pronto"
+  "Ready": "Pronto",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/ja.json
+++ b/data/i18n/ja.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "準備完了"
+  "Ready": "準備完了",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/nl.json
+++ b/data/i18n/nl.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Gereed"
+  "Ready": "Gereed",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/no.json
+++ b/data/i18n/no.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Klar"
+  "Ready": "Klar",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/pl.json
+++ b/data/i18n/pl.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Gotowe"
+  "Ready": "Gotowe",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/pt.json
+++ b/data/i18n/pt.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Pronto"
+  "Ready": "Pronto",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/ru.json
+++ b/data/i18n/ru.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Готово"
+  "Ready": "Готово",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/sv.json
+++ b/data/i18n/sv.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "Klar"
+  "Ready": "Klar",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/data/i18n/zh_CN.json
+++ b/data/i18n/zh_CN.json
@@ -2428,5 +2428,6 @@
   "Step {k} of {n}": "Step {k} of {n}",
   "Working…": "Working…",
   "{n} s — still working": "{n} s — still working",
-  "Ready": "就绪"
+  "Ready": "就绪",
+  "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile.": "⚠ Alignment check: {p}% of the patches read very differently from what the chart asked the printer to print (ΔE over 15). The grid was probably misaligned on a scan — or a scan doesn't belong to this chart. Check the diagnostic images before trusting this profile."
 }

--- a/tests/test_scanin_dialog.py
+++ b/tests/test_scanin_dialog.py
@@ -818,3 +818,119 @@ def test_busy_bar_always_visible_animated_only_while_running(_app, tmp_path):
         assert dlg._busy_bar._label == dlg.BUSY_BAR_IDLE_LABEL
     finally:
         dlg.deleteLater()
+
+
+# ---------------------------------------------------------------------------
+# #108 round 2 — user-supplied printtarg .cht alignment (Knut's ΔE>20 case)
+# ---------------------------------------------------------------------------
+
+_PRINTTARG_CHT = """BOXES 6
+  F _ _ 10.25 10.25 66.75 10.25 66.75 34.75 10.25 34.75
+  X A1 A1 _ _ 10.5 7.0 17.5 17.5 0 0
+  X A2 A2 _ _ 10.5 7.0 17.5 24.5 0 0
+  X B1 B1 _ _ 7.0 7.0 28.0 17.5 0 0
+  X B2 B2 _ _ 7.0 7.0 28.0 24.5 0 0
+  X C1 C1 _ _ 7.0 7.0 35.0 17.5 0 0
+  X C2 C2 _ _ 7.0 7.0 35.0 24.5 0 0
+
+BOX_SHRINK 2.0
+"""
+
+
+def test_chromiq_mode_rewrites_f_to_patch_bbox(_app, tmp_path):
+    """#108: a printtarg -s .cht carries real fiducial marks OUTSIDE the patch
+    area. The user aligns the marquee on the patches, so the cht handed to
+    scanin must carry F = the patch bbox — skipping that rewrite compressed
+    Knut's grid downward (bottom row right, everything above shifted)."""
+    src = tmp_path / "Printer_01.cht"
+    src.write_text(_PRINTTARG_CHT)
+    dlg = _dialog(_app)
+    try:
+        assert not dlg._standard_mode()          # ChromIQ-chart mode
+        out = dlg._prepare_scanin_cht(src, [(0, 0), (99, 0), (99, 49), (0, 49)],
+                                      1.0, tmp_path / "Printer", "t")
+        fline = next(l for l in out.read_text().splitlines()
+                     if l.strip().startswith("F "))
+        nums = [float(v) for v in fline.split()[3:]]
+        # Patch bbox: x 17.5..42.0, y 17.5..31.5 — not the outer 10.25..66.75.
+        assert nums[0] == 17.5 and nums[1] == 17.5
+        assert nums[2] == 42.0 and nums[5] == 31.5
+    finally:
+        dlg.deleteLater()
+
+
+def test_nonuniform_printtarg_grid_keeps_true_boxes(_app):
+    """#108: printtarg's first column is wider (10.5 vs 7 mm). The uniform-grid
+    fast path must reject it — on screen (per-box overlay) AND in the cht
+    scanin reads (no rectarg integer-edge rewrite)."""
+    from ui.scan_grid_marquee import GridSpec, rectarg_align_cht
+    g = GridSpec.from_cht(_PRINTTARG_CHT)
+    assert len(g.rects) == 6
+    assert g.ncols == 0                          # per-box mode
+    widths = sorted({round(r[2], 3) for r in g.rects})
+    assert len(widths) == 2                      # the wide column survives
+    assert rectarg_align_cht(_PRINTTARG_CHT, 5000, 2500) == _PRINTTARG_CHT
+    # A truly uniform grid still gets the fast path.
+    uniform = _PRINTTARG_CHT.replace("10.5 7.0", "7.0 7.0").replace(
+        "X A1 A1 _ _ 7.0 7.0 17.5", "X A1 A1 _ _ 7.0 7.0 21.0").replace(
+        "X A2 A2 _ _ 7.0 7.0 17.5", "X A2 A2 _ _ 7.0 7.0 21.0")
+    gu = GridSpec.from_cht(uniform)
+    assert gu.ncols > 0
+
+
+def test_marquee_can_zoom_out_below_fit(_app):
+    """#108: the corner handles sit outside the patch area — on a borderless
+    full-page scan they were unreachable at fit zoom. 10% zoom-out is allowed."""
+    from PyQt6.QtGui import QImage
+    from ui.scan_grid_marquee import ScanGridMarquee
+    m = ScanGridMarquee()
+    img = QImage(200, 100, QImage.Format.Format_RGB32)
+    img.fill(0xFFFFFFFF)
+    m.set_image(img)
+    m.resize(400, 300)
+    m._zoom_at_centre(0.5)                       # try to zoom far out
+    assert abs(m._zoom - 0.9) < 1e-9             # clamped at 90%, not 100%
+    m._reset_view()
+    assert m._zoom == 1.0
+
+
+def test_misalignment_warning_fires_on_scrambled_read(_app, tmp_path):
+    """#108: Knut's misaligned build produced ΔE>20 silently. The sanity check
+    compares the scanner read against the chart aims and warns when >10% of
+    patches are >ΔE15 off; an aligned read stays quiet."""
+    locs = [f"P{i}" for i in range(1, 21)]
+
+    def _write(path, vals):
+        rows = "\n".join(
+            f'{i + 1} "{loc}" 50.0 50.0 50.0 {x:.2f} {y:.2f} {z:.2f}'
+            for i, (loc, (x, y, z)) in enumerate(zip(locs, vals)))
+        path.write_text(f"""CTI3
+
+KEYWORD "SAMPLE_LOC"
+NUMBER_OF_FIELDS 8
+BEGIN_DATA_FORMAT
+SAMPLE_ID SAMPLE_LOC RGB_R RGB_G RGB_B XYZ_X XYZ_Y XYZ_Z
+END_DATA_FORMAT
+NUMBER_OF_SETS {len(locs)}
+BEGIN_DATA
+{rows}
+END_DATA
+""")
+
+    aims = [(20 + i * 3.0, 20 + i * 3.0, 20 + i * 3.0) for i in range(20)]
+    _write(tmp_path / "chart.ti2", aims)
+    dlg = _dialog(_app)
+    try:
+        # Aligned: reads == aims → quiet.
+        _write(tmp_path / "good.ti3", aims)
+        dlg._warn_if_misaligned(tmp_path / "good.ti3", tmp_path / "chart.ti2")
+        assert "Alignment check" not in dlg._log.toPlainText()
+        # Scrambled: a third of the patches read a very different colour.
+        bad = list(aims)
+        for i in range(0, 20, 3):
+            bad[i] = (90.0, 20.0, 5.0)
+        _write(tmp_path / "bad.ti3", bad)
+        dlg._warn_if_misaligned(tmp_path / "bad.ti3", tmp_path / "chart.ti2")
+        assert "Alignment check" in dlg._log.toPlainText()
+    finally:
+        dlg.deleteLater()

--- a/ui/dialogs/scanin_dialog.py
+++ b/ui/dialogs/scanin_dialog.py
@@ -1722,16 +1722,25 @@ class ScannerProfileDialog(_ToolDialogBase):
         return extrapolate_to_fiducials(corners, text) or corners
 
     def _apply_fiducial_frame(self, cht: Path, base: Path) -> Path:
-        """The bundled ``.cht``'s ``F`` line is the real fiducial marks. When "Use
+        """The ``.cht``'s ``F`` line is the real fiducial marks. When "Use
         fiducial marks" is ON, hand scanin that file unchanged — the user placed
         the marquee corners on the marks, and ``-F`` maps them to the ``F`` line.
-        When OFF, rewrite ``F`` to the patch-area bounding box, so ``-F`` maps the
-        corners the user placed on the patch grid instead."""
-        if not self._standard_mode() or self._use_fiducials_cb.isChecked():
-            return cht                              # ON (or engine): F already right
+        Otherwise rewrite ``F`` to the patch-area bounding box, so ``-F`` maps
+        the corners the user placed on the patch grid instead.
+
+        The rewrite runs for ChromIQ-chart mode too (#108): an engine chart's
+        ``F`` already IS the patch bbox (the rewrite is a no-op), but a
+        user-supplied printtarg ``-s`` .cht carries real corner marks OUTSIDE
+        the patch area — Knut's charts have them 7 mm out on three sides, so
+        skipping the rewrite compressed the whole grid downward."""
+        if self._standard_mode() and self._use_fiducials_cb.isChecked():
+            return cht                # ON: corners were placed on the real marks
         import re
         from workflow.cht_parser import ChtParseError, parse_cht
-        txt = cht.read_text(errors="ignore")
+        try:
+            txt = cht.read_text(errors="ignore")
+        except OSError:
+            return cht
         try:
             geom = parse_cht(txt)
         except ChtParseError:
@@ -1950,9 +1959,49 @@ class ScannerProfileDialog(_ToolDialogBase):
         self._jobs.append({"kind": "colprof_printer", "pbase": pbase, "base": base})
         self._run_job(0)
 
+    def _warn_if_misaligned(self, ti3: Path, ti2: Path) -> None:
+        """Knut's misalignment sanity check (#108): compare what the scanner
+        read (through its profile) against the chart's aim values, patch by
+        patch. A misplaced grid — or a scan of the wrong chart — scrambles the
+        assignment, so a large share of patches lands far off. Printer drift
+        moves colours too, but structuredly and mostly within bounds; the
+        thresholds (ΔE76 > 15 on more than 10% of patches) flag scrambles, not
+        an uncalibrated printer. Warning only — the build continues."""
+        try:
+            from workflow.icc_info import xyz_to_lab
+            from workflow.ti3_analysis import parse_ti3
+            got = parse_ti3(ti3)
+            aim = parse_ti3(ti2)
+            aim_by_id = dict(zip(aim.sample_ids, aim.xyz))
+            # Normalise each side to its own brightest patch, so exposure /
+            # paper-white scale differences don't count as colour error.
+            got_w = max(y for _x, y, _z in got.xyz) or 1.0
+            aim_w = max(y for _x, y, _z in aim_by_id.values()) or 1.0
+            n = big = 0
+            for sid, g in zip(got.sample_ids, got.xyz):
+                a = aim_by_id.get(sid)
+                if a is None:
+                    continue
+                gl = xyz_to_lab(tuple(c * 100.0 / got_w for c in g))
+                al = xyz_to_lab(tuple(c * 100.0 / aim_w for c in a))
+                de = sum((x - y) ** 2 for x, y in zip(gl, al)) ** 0.5
+                n += 1
+                big += de > 15.0
+            if n and big / n > 0.10:
+                self._log.appendPlainText(tr(
+                    "⚠ Alignment check: {p}% of the patches read very "
+                    "differently from what the chart asked the printer to "
+                    "print (ΔE over 15). The grid was probably misaligned on "
+                    "a scan — or a scan doesn't belong to this chart. Check "
+                    "the diagnostic images before trusting this profile."
+                ).format(p=round(100 * big / n)))
+        except Exception:  # noqa: BLE001 — a sanity check must never block
+            log.warning("misalignment check failed", exc_info=True)
+
     def _build_printer_profile(self, pbase: Path, base: Path) -> None:
         ti3 = pbase.with_suffix(".ti3")
         self._sanitize_scanner_ti3(ti3)              # once, on the accumulated .ti3
+        self._warn_if_misaligned(ti3, base.with_suffix(".ti2"))
         self._log.appendPlainText(tr("Building the printer profile…"))
         ti3, custom = self._apply_profile_name(ti3)
         params = ProfileParams(

--- a/ui/scan_grid_marquee.py
+++ b/ui/scan_grid_marquee.py
@@ -139,8 +139,15 @@ def rectarg_align_cht(text: str, wpx: float, hpx: float) -> str:
     sw, sh = (x1 - x0) or 1.0, (y1 - y0) or 1.0
     dxs = [xl[i + 1] - xl[i] for i in range(nc - 1)]
     dys = [yt[i + 1] - yt[i] for i in range(nr - 1)]
-    if max(dxs) - min(dxs) > 0.02 * sw or max(dys) - min(dys) > 0.02 * sh:
+    # Same pitch-relative uniformity rule as GridSpec._grid_structure (#108):
+    # non-uniform charts (printtarg's wider first column) keep their true boxes.
+    if (max(dxs) - min(dxs) > 0.1 * min(dxs)
+            or max(dys) - min(dys) > 0.1 * min(dys)):
         return text                                # not a uniform grid
+    bws = sorted({round(b.x2 - b.x1, 2) for b in boxes})
+    bhs = sorted({round(b.y2 - b.y1, 2) for b in boxes})
+    if bws[-1] - bws[0] > 0.05 * bws[-1] or bhs[-1] - bhs[0] > 0.05 * bhs[-1]:
+        return text
     xi = {v: i for i, v in enumerate(xl)}; yi = {v: i for i, v in enumerate(yt)}
     ue, ve = rectarg_edges(wpx, nc), rectarg_edges(hpx, nr)
     newpos = {}
@@ -231,8 +238,19 @@ class GridSpec:
             return 0, 0, None
         dxs = [xl[i + 1] - xl[i] for i in range(nc - 1)]
         dys = [yt[i + 1] - yt[i] for i in range(nr - 1)]
-        if max(dxs) - min(dxs) > 0.02 * sw or max(dys) - min(dys) > 0.02 * sh:
+        # Tolerance relative to the PITCH, not the whole span — a 2%-of-span
+        # test waved through printtarg's wider first column (10.5 vs 7 mm on a
+        # 262 mm chart), forcing 962 boxes onto equal cells (#108).
+        if (max(dxs) - min(dxs) > 0.1 * min(dxs)
+                or max(dys) - min(dys) > 0.1 * min(dys)):
             return 0, 0, None          # not uniform (e.g. a whole column missing)
+        # Equal cells also require equal BOX sizes (#108).
+        def gw(p): return round((p.x2 - p.x1) if hasattr(p, "x1") else p["w"], 2)
+        def gh(p): return round((p.y2 - p.y1) if hasattr(p, "y1") else p["h"], 2)
+        ws = sorted({gw(p) for p in patches})
+        hs = sorted({gh(p) for p in patches})
+        if ws[-1] - ws[0] > 0.05 * ws[-1] or hs[-1] - hs[0] > 0.05 * hs[-1]:
+            return 0, 0, None
         xi = {v: i for i, v in enumerate(xl)}
         yi = {v: i for i, v in enumerate(yt)}
         return nc, nr, [(xi[gx(p)], yi[gy(p)]) for p in patches]
@@ -722,8 +740,11 @@ class ScanGridMarquee(QWidget):
             return
         cx, cy = self.width() / 2.0, self.height() / 2.0
         ix, iy = self._to_image(cx, cy)
-        self._zoom = max(1.0, min(16.0, self._zoom * factor))
-        if self._zoom <= 1.0:
+        # Floor below the exact fit (0.9): on a borderless full-page scan the
+        # corner handles sit outside the image and were unreachable at fit
+        # zoom — Knut had to pan for every corner (#108).
+        self._zoom = max(0.9, min(16.0, self._zoom * factor))
+        if self._zoom <= 0.9 + 1e-9:
             self._pan = [0.0, 0.0]
         else:
             s = self._scale * self._zoom
@@ -742,7 +763,7 @@ class ScanGridMarquee(QWidget):
             return
         pos = e.position()
         ix, iy = self._to_image(pos.x(), pos.y())
-        self._zoom = max(1.0, min(16.0, self._zoom * (1.0015 ** e.angleDelta().y())))
+        self._zoom = max(0.9, min(16.0, self._zoom * (1.0015 ** e.angleDelta().y())))
         if self._zoom <= 1.0:
             self._pan = [0.0, 0.0]               # fit → recentre
         else:                                    # keep point under cursor fixed


### PR DESCRIPTION
Fixes the second round of #108 — Knut aligned the marquee perfectly and still got a ΔE>20 profile. Both root causes reproduced and verified against his attached 5-page chart (`Printer.ti2` + `Printer_01…05.cht`).

## Bug 1 — corners mapped to the wrong frame

His printtarg `-s` chts carry the **real fiducial F line ~7 mm outside the patch area on three sides (0.25 mm at the bottom)**. The marquee corners are placed on the patch area, but ChromIQ-chart mode skipped the patch-bbox F rewrite (the "engine: F already right" assumption — true for engine charts, wrong for BYO printtarg charts). scanin therefore stretched the patch grid to the outer frame: compressed downward, bottom row correct — exactly his diagnostic image. `_apply_fiducial_frame` now runs for ChromIQ-chart mode too (a byte-level no-op for engine charts, whose F already is the patch bbox), matching the proven standard-mode-OFF pipeline he suspected wasn't being reused.

## Bug 2 — the wider first column was flattened

printtarg's first column is 10.5 mm vs 7.0 mm. The uniform-grid detection tolerated spacing scatter up to **2% of the chart span** (5.25 mm here), so a 3.5 mm pitch difference passed as "uniform" — the on-screen overlay drew 37 equal columns *and* `rectarg_align_cht` rewrote all 962 scanin boxes onto equal cells. Both detectors (`GridSpec._grid_structure`, `rectarg_align_cht`) now use a pitch-relative tolerance and additionally require uniform box sizes. Non-uniform charts keep their true per-box geometry on screen and in the cht scanin reads; truly uniform rectarg targets keep the integer-edge fast path (multi-dpi suite still passes with worst error 0.0).

## Knut's two suggestions, both in

- **Misalignment sanity check:** after the pages are read, the scanner read is compared patch-by-patch against the chart's aims (white-normalised ΔE76). More than 10% of patches over ΔE 15 logs a clear warning — misaligned grid or scan/chart mismatch — before colprof runs.
- **Zoom-out headroom:** the marquee now zooms out to 90% of the fit, so the corner handles (which sit outside the patch area) stay reachable on borderless full-page scans without panning per corner.

## Verification

End-to-end with his real files: prepared cht F = `17.5,17.5 – 280,199.5` (the true patch bbox), 962-box per-page overlay in per-box mode, wide A1 column preserved, corners passed through unchanged. New tests cover the F rewrite, non-uniform detection (plus the uniform fast path staying on), the zoom floor, and the ΔE warning firing on a scrambled read and staying quiet on an aligned one. Full suite: **1618 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)