### PR TITLE
Make the release gate green on Windows (5 test/fixture portability fixes)

### DIFF
--- a/scripts/make_demo_projects.py
+++ b/scripts/make_demo_projects.py
@@ -174,7 +174,17 @@ def _build_icc(run_dir: Path, stem: str) -> bool:
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
         print(f"    (colprof failed for {stem}: {exc}) — no profile written")
         return False
-    return (run_dir / f"{stem}.icc").is_file()
+    # ArgyllCMS writes the Windows ICC extension (.icm) on Windows and .icc on
+    # macOS/Linux. ChromIQ's demo layout — and Run.profile_icc — is spelled .icc
+    # everywhere, so canonicalise the output. Without this a demo built on
+    # Windows has <stem>.icm and looks profile-less to any test that checks
+    # Run.profile_icc (#130, Windows gate). The app itself tolerates either name
+    # via ProfileBuilder.expected_icc_path(); the demo just picks the canonical one.
+    icc = run_dir / f"{stem}.icc"
+    icm = run_dir / f"{stem}.icm"
+    if not icc.is_file() and icm.is_file():
+        icm.replace(icc)
+    return icc.is_file()
 
 
 def _write_tiff(path: Path, page: int) -> None:
@@ -217,6 +227,18 @@ def _argyll(tool: str) -> str:
     found = shutil.which(tool)
     if found:
         return found
+    # Fall back to ChromIQ's own cross-platform detection. On Windows Argyll
+    # lives under %LOCALAPPDATA%\ArgyllCMS\Argyll_V*\bin — neither a macOS path
+    # above nor on PATH — so without this the demo fixtures could not build and
+    # every test that needs them errored (#130, Windows gate). find_argyll_bin_path()
+    # is the same resolver the app uses; argyll_binary() adds the .exe on Windows.
+    from core.argyll_detect import find_argyll_bin_path
+    from core.resource_path import argyll_binary
+    bin_dir = find_argyll_bin_path()
+    if bin_dir is not None:
+        exe = bin_dir / argyll_binary(tool)
+        if exe.exists():
+            return str(exe)
     raise SystemExit(f"ArgyllCMS {tool} not found — install it, or set PATH.")
 
 

--- a/tests/_fontcheck.py
+++ b/tests/_fontcheck.py
@@ -1,0 +1,37 @@
+"""Shared guard for tests that assert on real font glyph advances.
+
+A number of tests measure widths — button fits, tree-connector alignment, the
+masthead / measurement-target-bar layout — with ``QFontMetrics.horizontalAdvance``
+and friends. Those numbers only mean something when the Qt font database holds
+real fonts.
+
+Under ``QT_QPA_PLATFORM=offscreen`` that holds on macOS (the offscreen platform
+still exposes the system fonts, which is why these tests pass on the release
+gate) but NOT on Windows, where the offscreen platform exposes an **empty** font
+database: every family requested falls back to a null font, so ``the label is
+288px`` and ``uppercase Menlo is wider`` are measured against nothing and the
+assertions are meaningless rather than wrong.
+
+So these tests skip cleanly when the fonts they need are not present, instead of
+failing on un-measurable numbers. The macOS gate — where the fonts are real —
+remains the authority and is unaffected.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def skip_without_fonts() -> None:
+    """Skip when this Qt/QPA exposes no real font families at all."""
+    from PyQt6.QtGui import QFontDatabase
+    if not QFontDatabase.families():
+        pytest.skip("this Qt/QPA exposes no font families — glyph-advance "
+                    "assertions cannot be measured (offscreen on Windows)")
+
+
+def skip_without_family(family: str) -> None:
+    """Skip when a specific font *family* does not resolve here."""
+    from PyQt6.QtGui import QFont, QFontInfo
+    skip_without_fonts()
+    if QFontInfo(QFont(family)).family().lower() != family.lower():
+        pytest.skip(f"font {family!r} is not available in this Qt font database")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,12 @@ import tempfile
 
 import pytest
 
+# Make helper modules that live beside the tests (e.g. ``tests/_fontcheck.py``)
+# importable with a bare ``import _fontcheck`` from any test. pytest puts the
+# rootdir on sys.path but not reliably this directory, so without it such an
+# import fails depending on the import mode.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 # On Windows/ARM, make freetype-py find our vendored ARM64 FreeType before any
 # test imports `freetype` (e.g. test_vector_pdf collects it at module load), so
 # the vector-PDF tests actually run there instead of skipping (#72). No-op on

--- a/tests/test_button_text_fits.py
+++ b/tests/test_button_text_fits.py
@@ -59,6 +59,8 @@ def test_a_button_is_wide_enough_for_the_font_it_paints_with(qapp, label):
 def test_the_uppercase_swap_is_what_the_width_is_measured_against(qapp):
     """The bug in one assertion: sizing against the *pre-swap* font is not
     enough, so a width taken before the filter runs must not be trusted."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # the swap only widens if Menlo is real
     btn = QPushButton("Replace the stored chart")
     before = QFontMetrics(btn.font()).horizontalAdvance(btn.text())
     ButtonFontFilter.fit(btn)
@@ -358,6 +360,8 @@ def test_a_label_fits_in_the_system_font_too(qapp):
     from PyQt6.QtWidgets import QPushButton
 
     from ui.widgets import ButtonFontFilter
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # needs the system font's real metrics
 
     system = QFontDatabase.systemFont(QFontDatabase.SystemFont.GeneralFont)
     for label in ("Delete run 4 permanently", "Delete run 10 permanently",

--- a/tests/test_duplicate_run_core.py
+++ b/tests/test_duplicate_run_core.py
@@ -64,7 +64,10 @@ def project(tmp_path):
 
 
 def _names(run):
-    return {str(p.relative_to(run.dir))
+    # as_posix() so subfolder paths use "/" on every platform — the assertions
+    # below compare against forward-slash literals ("chart/…", "reads/…"), which
+    # str() breaks on Windows by joining with os.sep ("\").
+    return {p.relative_to(run.dir).as_posix()
             for p in run.dir.rglob("*") if p.is_file()}
 
 

--- a/tests/test_file_guide_structure.py
+++ b/tests/test_file_guide_structure.py
@@ -93,6 +93,8 @@ def test_the_connectors_are_equal_width_in_the_faces_the_card_asks_for():
     from PyQt6.QtGui import QFont, QFontInfo, QFontMetrics
     from PyQt6.QtWidgets import QApplication
     _app = QApplication.instance() or QApplication([])
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                  # no fonts here → none to measure
     checked = 0
     for family in ("Menlo", "Monaco", "Courier New"):
         f = QFont(family)

--- a/tests/test_knut_beta77_batch.py
+++ b/tests/test_knut_beta77_batch.py
@@ -124,6 +124,8 @@ def test_fitting_is_now_enough_whichever_font_paints_it(qapp):
     from PyQt6.QtGui import QFontDatabase, QFontMetrics
 
     from ui.widgets import fit_button_width
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                        # needs real font metrics
     label = "Delete run 4 permanently"
     btn = QPushButton(label)
     fit_button_width(btn)                       # without the swap

--- a/tests/test_masthead_center_fits.py
+++ b/tests/test_masthead_center_fits.py
@@ -212,6 +212,8 @@ def test_a_narrow_rail_squeezes_the_bar_instead_of_letting_it_overrun(qapp,
                                                                       tmp_path):
     """With more to show than the rail can hold, the widest box gives up width
     — the bar never runs under the version text, and never over itself."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # layout pivots on real text widths
     from core.measurement_target import RUN_TYPE_VERIFICATION
     from ui.styles import APP_STYLESHEET
     mast, bar, ctl = _mast_with_bar(
@@ -241,6 +243,8 @@ def test_a_narrow_rail_squeezes_the_bar_instead_of_letting_it_overrun(qapp,
 
 def test_the_comfortable_width_comes_back_when_there_is_room(qapp, tmp_path):
     """Squeezing is a concession to a narrow window, not a new normal."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # layout pivots on real text widths
     from core.measurement_target import RUN_TYPE_VERIFICATION
     from ui.styles import APP_STYLESHEET
     mast, bar, ctl = _mast_with_bar(

--- a/tests/test_platform_file_manager_name.py
+++ b/tests/test_platform_file_manager_name.py
@@ -98,16 +98,25 @@ def test_no_user_text_pairs_them_by_hand():
 
 def test_every_manager_placeholder_is_actually_filled():
     """A ``{manager}`` left unformatted would be shown to the user verbatim."""
-    import subprocess
-    src = subprocess.run(
-        ["grep", "-rn", "{manager}", "--include=*.py", "ui", "core", "workflow"],
-        cwd=ROOT, capture_output=True, text=True).stdout
-    assert src.strip(), "the placeholder has vanished — did the strings change?"
+    # Scan for the *literal* "{manager}" in Python, not via `grep`: the pattern
+    # is a regex to grep, and the two greps disagree — BSD grep (macOS) treats
+    # "{manager}" as literal braces, GNU grep (Windows/Linux) matches the bare
+    # word "manager", dragging in every file that says "manager" in prose. A
+    # plain substring test is deterministic on every platform (and needs no
+    # grep on PATH, nor a locale-correct decode of its output).
+    files = set()
+    for entry in SCANNED:
+        for path in (ROOT / entry).rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            if "{manager}" in path.read_text(encoding="utf-8"):
+                files.add(path)
+    assert files, "the placeholder has vanished — did the strings change?"
     # every file that mentions the placeholder must also call the helper
-    files = {line.split(":")[0] for line in src.splitlines() if line.strip()}
-    for f in files:
-        text = (ROOT / f).read_text(encoding="utf-8")
-        assert "file_manager_name()" in text, f"{f} never fills {{manager}}"
+    for path in sorted(files):
+        text = path.read_text(encoding="utf-8")
+        assert "file_manager_name()" in text, \
+            f"{path.relative_to(ROOT)} never fills {{manager}}"
 
 
 @pytest.mark.parametrize("platform_name", ["Finder", "File Explorer",

--- a/tests/test_target_bar_alignment.py
+++ b/tests/test_target_bar_alignment.py
@@ -63,6 +63,8 @@ def _visible_row_widgets(bar):
 
 def test_the_row_does_not_stretch_across_the_window(qapp, tmp_path):
     """Profiling shows two boxes; they must sit at the left, not at the edges."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # box positions pivot on real text widths
     bar = _bar(tmp_path)
     widgets = _visible_row_widgets(bar)
     assert widgets, "the row should have visible widgets"
@@ -93,6 +95,8 @@ def test_neighbours_stay_at_the_row_spacing(qapp, tmp_path):
 def test_verification_adds_its_boxes_on_the_right(qapp, tmp_path):
     """Knut's requirement stated positively: the extra boxes appear to the
     right of the existing ones, which do not move."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # box positions pivot on real text widths
     bar = _bar(tmp_path)
     before = {id(w): w.x() for w in _visible_row_widgets(bar)}
     # Measured up to the last *selector* — the bar's ⓘ closes the row and the
@@ -136,6 +140,8 @@ def test_verification_adds_its_boxes_on_the_right(qapp, tmp_path):
 def test_a_long_location_line_does_not_spread_the_row(qapp, tmp_path):
     """The location line is the widest thing in the bar — its width must not
     reach the row above it."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # row width pivots on real text widths
     bar = _bar(tmp_path)
     bar._location.setText("ChromIQ/" + "a-very-long-project-name/" * 6)
     QApplication.processEvents()

--- a/tests/test_target_bar_stability.py
+++ b/tests/test_target_bar_stability.py
@@ -203,6 +203,8 @@ def test_the_hint_takes_the_room_up_to_the_version_text(qapp, tmp_path):
     is left of it rather than share it with the row's trailing stretch, which is
     what wrapped it into a narrow column of four lines.
     """
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # hint width pivots on real text widths
     bar = _hint_bar(tmp_path, 1400)
     row = bar.layout().itemAt(0).layout()
     boxes_end = max(row.itemAt(i).widget().geometry().right()
@@ -229,6 +231,8 @@ def test_the_box_follows_the_window_width(qapp, tmp_path):
     # test_a_narrow_bar_puts_the_sentence_under_the_row. What THIS test is
     # about is unchanged: while it does sit beside, its width follows the
     # window.
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # box width pivots on real text widths
     widths = []
     for avail in (1400, 1600, 1800):
         bar = _hint_bar(tmp_path, avail)
@@ -254,6 +258,8 @@ def test_a_rail_too_narrow_for_it_puts_it_under_the_row_instead(qapp, tmp_path):
     give the sentence forty pixels — one word wide and twenty-one lines tall
     (measured). It goes under the row at that point, and comes back up as soon
     as there is room."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # beside/below pivots on real text widths
     narrow = _hint_bar(tmp_path, 700)
     assert not narrow._hint_beside
     assert narrow._hint.y() > narrow.layout().itemAt(0).layout().geometry().bottom() - 1
@@ -271,6 +277,8 @@ def test_the_bar_never_grows_absurdly_tall(qapp, tmp_path):
 
 
 def test_only_the_location_line_is_below_when_it_fits_beside(qapp, tmp_path):
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # beside/below pivots on real text widths
     bar = _hint_bar(tmp_path, 1600)
     assert bar._hint_beside
     assert bar._hint.y() < bar._location.y()


### PR DESCRIPTION
## Summary

The full `--runslow` release gate passes on the macOS host but had **17 failures + 17 errors** on a native **Windows 11 ARM64** run. Every one was a **test/fixture portability gap — no product regression**; application code is untouched.

After these fixes the gate is **0 failed, 0 errors on Windows** (`4258 passed, 137 skipped`) and **unchanged on macOS** — each fix is a no-op where macOS already did the right thing. Two of them (grep, `.icm`) would also have failed on a Linux runner, so they harden the suite beyond Windows.

## The five fixes

| # | Root cause | Fix | Was |
|---|---|---|---|
| 1 | Demo builder searched only macOS Argyll paths + PATH; Windows keeps Argyll under `%LOCALAPPDATA%\ArgyllCMS\Argyll_V*\bin` | `_argyll()` falls back to the app's own `find_argyll_bin_path()` | 17 errors |
| 2 | `colprof` writes `.icm` on Windows, `.icc` on macOS/Linux; `Run.profile_icc` is `.icc` everywhere | `_build_icc()` canonicalises the output to `.icc` | 2 failures |
| 3 | `_names()` joined with `str()` → `chart\Demo.ti2`; assertions compare `chart/Demo.ti2` | use `Path.as_posix()` | 3 failures |
| 4 | `grep "{manager}"`: BSD grep treats braces literally, GNU grep (Win **and** Linux) matches bare `manager` | pure-Python literal scan, no grep | 1 failure |
| 5 | `QT_QPA_PLATFORM=offscreen` exposes an empty font DB on Windows (system fonts on macOS), so glyph-advance asserts measure a null font | new `tests/_fontcheck.py::skip_without_fonts()` skips those cleanly when no real fonts exist | 13 failures |

## Safety / scope

- **macOS gate is the authority and is unaffected** — Argyll is at a macOS path, `colprof` already writes `.icc`, separators are `/`, BSD grep is literal, and the offscreen font DB is populated. The font-guarded tests still run there.
- No application code changed — only `scripts/make_demo_projects.py` (a test fixture) and `tests/`.
- Verified: full `--runslow -n auto` on Windows 11 ARM64 / Python 3.12.10 → `4258 passed, 137 skipped, 2 xfailed, 0 failed, 0 errors`.

## Follow-up (separate, not in this PR)

On Windows the *real app* leaves a built profile as `.icm`; `Run.built_profile_icc()` / `profile_rebuild_guard.py` only look for `.icc`/`merged.icc`, so a Windows-built profile could be misjudged as "not built". Worth a look if Windows becomes a shipped target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
