### PR TITLE
Keep the Windows gate green: font guard + test log isolation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,23 @@ import tempfile
 import pytest
 
 
+# Keep the suite off the user's real application log. core.logger's
+# configure_logging() installs a RotatingFileHandler on the real
+# ~/.../ChromIQ/Logs/chromiq.log and returns early if the root logger already
+# has a handler. Pre-install a NullHandler here — BEFORE the first `core` import
+# below triggers configure_logging() — so the app never attaches its file
+# handler during tests: the real log is left untouched, and nothing is written
+# to disk to clean up afterwards. On Windows this also removes ~1000 lines of
+# swallowed "PermissionError: [WinError 32]" per gate run — the four xdist
+# workers were each rotating that one shared 5 MB file, and Windows refuses to
+# rename a file another process still holds open. pytest's own log capture
+# (caplog) attaches its handler independently and is unaffected.
+import logging as _logging
+_root_logger = _logging.getLogger()
+if not _root_logger.handlers:
+    _root_logger.addHandler(_logging.NullHandler())
+    _root_logger.setLevel(_logging.DEBUG)
+
 
 #: The highest worker count this suite is currently RELIABLE at — see CLAUDE.md
 #: for the measurements. Kept here as a fact, not enforced: capping ``-n auto``

--- a/tests/test_masthead_center_fits.py
+++ b/tests/test_masthead_center_fits.py
@@ -69,6 +69,8 @@ def test_rail_grows_so_a_taller_widget_still_fits(qapp, h):
 
 def test_the_real_target_bar_fits_on_the_rail(qapp, tmp_path):
     """The case that actually broke: the two-line Profile-run bar."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # rail/bar geometry pivots on real text widths
     s = AppSettings(); s._qs = QSettings(str(tmp_path / "s.ini"), QSettings.Format.IniFormat)
     root = tmp_path / "ChromIQ"; root.mkdir()
     s.set("custom_output_path", str(root))


### PR DESCRIPTION
## Summary

Two small, **test-only** follow-ups to #138, found running the beta.144 release gate natively on **Windows 11 ARM64**. Application code is untouched, and the macOS gate is unaffected. After these the full `--runslow` gate is **0 failed / 0 errors on Windows** (`4373 passed, 139 skipped`), with no stderr noise.

## The two fixes

**1. A font-metric test slipped back in (1 failure).**
`test_masthead_center_fits.py` was rewritten between beta.141 and beta.144 (after #138 merged), and its `test_the_real_target_bar_fits_on_the_rail` asserts the Profile-run bar's geometry fits the masthead rail — which depends on real glyph advances. Under `QT_QPA_PLATFORM=offscreen` the font database is empty on Windows (populated on macOS, which is why it passes on the host), so the bar is mis-measured and overflows by 12 px. Same class as the guards #138 added; it just post-dated that PR. Guarded with `skip_without_fonts()`.

**2. The suite churned the real application log (~1000 `WinError 32`/run).**
`core.logger.configure_logging()` installs a `RotatingFileHandler` on the *real* `~/.../ChromIQ/Logs/chromiq.log` and returns early if the root logger already has a handler. `conftest.py` now pre-installs a `NullHandler` before the first `core` import, so during tests the app leaves the real log alone and writes nothing to disk to clean up. On Windows this also removes ~1000 lines of swallowed `PermissionError: [WinError 32]` per gate run — the four xdist workers were each rotating that one shared 5 MB file, and Windows refuses to rename a file another process still holds open (a no-op on macOS/Linux, where an open file renames fine — which is why the host never saw it).

## Why test-only, not an app change

`log_dir()` has no dedicated override, and a `CHROMIQ_LOG_DIR` env var would have broken `test_platform_paths` (which asserts the platform-derived path). Suppressing the handler in `conftest` is the minimal, side-effect-free route. `pytest`'s own log capture (`caplog`) attaches its handler independently and is unaffected; no test reads the app log.

## Verification

Full `--runslow -n 4` on Windows 11 ARM64 / Python 3.12.10:
```
4373 passed, 139 skipped, 2 xfailed, 0 failed, 0 errors
WinError 32 occurrences: 0   (was ~1155)
```
Cleanup swept 1.06 GB on the passing run; demo cache preserved. Unchanged on the macOS gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
