### PR TITLE
Keep the Windows gate green on beta.190 (guard new width tests)

### DIFF
--- a/tests/test_choice_dialog_button_width.py
+++ b/tests/test_choice_dialog_button_width.py
@@ -53,6 +53,8 @@ def _choices(name):
 
 def test_no_button_is_narrower_than_its_text(qapp):
     """The original fault: a button laid out before the font swap is too small."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # width >= hint pivots on real text widths
     _, buttons = _measure(qapp, _choices("Knut-Scanner"))
     assert buttons, "no buttons on the dialog"
     for text, width, hint in buttons:
@@ -67,6 +69,8 @@ def test_a_very_long_project_name_still_fits(qapp):
     Not a check that the name was shortened — a check that the row of buttons
     fits inside the window it is drawn in, which is the thing the user sees.
     """
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # button/window fit pivots on real text widths
     window, buttons = _measure(qapp, _choices(_short_name(_LONG)))
     total = sum(hint for _t, _w, hint in buttons)
     assert total <= window, (

--- a/tests/test_help_card_width.py
+++ b/tests/test_help_card_width.py
@@ -56,6 +56,8 @@ FREE_FLOWING = (
 
 def test_a_hand_wrapped_body_is_not_re_wrapped(qapp):
     """Every line the author wrote fits on one line on screen."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # re-wrap check pivots on real text widths
     dlg = _InfoDialog("Title", HAND_WRAPPED, None, 420)
     dlg.show()
     qapp.processEvents()
@@ -88,6 +90,8 @@ def test_free_flowing_prose_keeps_the_width_its_caller_asked_for(qapp):
     Its "longest line" is the whole paragraph, so measuring it would push every
     such card to the maximum width.
     """
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # width check pivots on real text widths
     dlg = _InfoDialog("Title", FREE_FLOWING, None, 420)
     dlg.show()
     qapp.processEvents()
@@ -133,6 +137,10 @@ def test_the_real_patch_consistency_card(qapp):
         f"expected the Guided and Manual copies of the -T help card, "
         f"found {len(bodies)}"
     )
+    # The drift check above is platform-independent; the width measurement below
+    # needs real glyph advances, absent under offscreen Qt on Windows.
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()
     for raw in bodies:
         body = eval(raw, {"tr": lambda s: s})       # noqa: S307 — a literal
         dlg = _InfoDialog("Patch consistency tolerance (-T)", body, None, 420)

--- a/tests/test_translation_integrity.py
+++ b/tests/test_translation_integrity.py
@@ -205,6 +205,8 @@ _CHECKBOX_BUDGET = 163   # same column, minus the checkbox indicator
 @pytest.mark.parametrize("code", CODES)
 def test_translated_parameter_names_fit_their_column(code, qapp):
     """A name wider than its column is clipped behind the control beside it."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # column-fit pivots on real text widths
     import yaml
 
     from core import i18n


### PR DESCRIPTION
## Summary

Third small, **test-only** follow-up to #138/#139. beta.190 added three new test files that assert UI element widths against fixed, **macOS-tuned pixel budgets**, and 16 of their assertions failed on the Windows 11 ARM64 gate. All are the same root cause already handled twice: under `QT_QPA_PLATFORM=offscreen` the Qt font database is **empty on Windows** (populated on macOS — Qt literally warns *"no longer ships fonts"*), so `QFontMetrics.horizontalAdvance` / `QLabel.width()` measure a null fallback.

Guarded the six failing functions with `skip_without_fonts()` (the helper from #138). Application code untouched; macOS gate unaffected.

## Files

| File | Guarded tests |
|---|---|
| `test_translation_integrity.py` | `test_translated_parameter_names_fit_their_column` (parametrized ×12 languages) |
| `test_choice_dialog_button_width.py` | `test_a_very_long_project_name_still_fits`, `test_no_button_is_narrower_than_its_text` |
| `test_help_card_width.py` | `test_a_hand_wrapped_body_is_not_re_wrapped`, `test_free_flowing_prose_keeps_the_width_its_caller_asked_for`, `test_the_real_patch_consistency_card` (width loop only — its source-drift check still runs) |

## A note on flakiness

`test_no_button_is_narrower_than_its_text` passed in isolation but failed in the parallel gate. Cause: `test_splash.py` loads application fonts into the **per-worker** font DB, so a width test's outcome depends on whether a font-loading test ran earlier on its worker. The `families()`-based guard is correct under both states — it skips on an empty-DB worker and passes on one where real fonts are present (the app's own Inter measures comfortably under the budgets).

## Verification

Full `--runslow -n 4` on Windows 11 ARM64 / Python 3.12.10:
```
4698 passed, 166 skipped, 2 xfailed, 0 failed, 0 errors
WinError 32 occurrences: 0
```
Unchanged on the macOS gate.

## Recurring pattern (for consideration)

This is the third round of guarding macOS-tuned width tests for the Windows gate. Each batch of new UI-width tests reintroduces it. If keeping the Windows gate green matters ongoing, a lightweight convention would help — e.g. a `@needs_fonts` marker authors add to width-measuring tests, or a shared fixture. Happy to propose one separately; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
