### PR TITLE
Make the overlay-repro diagnostic opt-in, not path-triggered

### DIFF
--- a/tests/test_overlay_failure_reason.py
+++ b/tests/test_overlay_failure_reason.py
@@ -131,13 +131,21 @@ def test_no_measurement_at_all_is_not_a_geometry_claim(tmp_path):
     assert _Stub(ti2, None)._overlay_failure_reason() == "mismatch"
 
 
-@pytest.mark.skipif(not (os.path.expanduser("~/ChromIQ/printer-test/runs/run1"
-                                            "/printer-test.ti3")
-                         and os.path.isfile(os.path.expanduser(
-                             "~/ChromIQ/printer-test/runs/run1/printer-test.ti3"))),
-                    reason="the reporter's own project is not on this machine")
+_REPRO_TI3 = os.path.expanduser(
+    "~/ChromIQ/printer-test/runs/run1/printer-test.ti3")
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("CHROMIQ_REPRO_OVERLAY") and os.path.isfile(_REPRO_TI3)),
+    reason="set CHROMIQ_REPRO_OVERLAY to reproduce against the reporter's own "
+           "project. The old guard checked only that ~/ChromIQ/printer-test "
+           "EXISTED — which grabbed any unrelated project a user happened to "
+           "name the same (a real 'mismatch' project on a dev VM failed the "
+           "'no_geometry' assertion). The opt-in makes it run only when asked.")
 def test_the_reported_project_reproduces_it(tmp_path):
-    """Against the real files that produced the report, when they are present.
+    """Against the real files that produced the report — opt-in via
+    ``CHROMIQ_REPRO_OVERLAY=1`` with the reporter's project at
+    ``~/ChromIQ/printer-test``.
 
     Copied first: `Project.load` migrates in place and a test must never write
     into the user's own projects.


### PR DESCRIPTION
## Summary

`test_overlay_failure_reason.py::test_the_reported_project_reproduces_it` is a diagnostic that reproduces a reporter's bug against their own `~/ChromIQ/printer-test` project *"when the files are present."* Its `skipif` only tested that the path **existed**:

```python
os.path.expanduser("~/…/printer-test.ti3") and os.path.isfile(...)
```

The `expanduser(...)` string is always truthy, so the guard reduced to *"does the file exist?"* — it never verified the files were the reporter's. Any machine with an **unrelated** project someone happened to name `printer-test` had it copied and asserted against. A real `printer-test` project on a dev VM returns `'mismatch'`, not the `'no_geometry'` the reporter's data produces, so the gate failed on data unrelated to the bug.

## Fix

Gate it behind `CHROMIQ_REPRO_OVERLAY` — the same opt-in convention as the other `CHROMIQ_*` test overrides. It now **skips everywhere by default** (including a machine that happens to have a same-named project) and runs only when explicitly asked, with the reporter's project in place:

```bash
CHROMIQ_REPRO_OVERLAY=1 pytest tests/test_overlay_failure_reason.py
```

No application code changed.

## Verification

- Default (no env var): **skips**, even on a machine that *does* have a `~/ChromIQ/printer-test` project.
- `CHROMIQ_REPRO_OVERLAY=1` with the file present: **runs** (re-enabled).

This was the only failure on the beta.207 Windows gate; with it the gate is `4773 passed, 166 skipped, 2 xfailed, 0 failed` (the count that was failing here is now a skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
