### PR TITLE
Unwedge the Windows gate on beta.221 (native print modal + PDF-layout guard)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,30 @@ def _no_real_editor_render(monkeypatch):
                         lambda self, *a, **k: None, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _no_native_print_dialog(monkeypatch):
+    """Never let a test open the Qt native print dialog — it blocks for ever.
+
+    The same "passes on Mac, hangs on Windows" shape as the editor render above.
+    ``TabPrint._print_native_qt`` opens ``QPrintDialog(...).exec()``, a modal
+    with no one to click it, so any test that reaches it wedges the headless
+    suite until it is killed. And it IS reached on Windows even when a test sets
+    ``use_native_print_dialog`` False: ``AppSettings.get`` forces that flag True
+    on Windows (there is no ``lp`` there), so ``_on_print_current`` takes the
+    native branch, whereas on macOS the same branch goes to the driver-native
+    path instead of a Qt modal — which is why it only hangs on Windows (#130,
+    beta.221 gate). Tests that care about the print path stub ``_print_pages`` /
+    ``_print_native`` themselves and assert on the conversion + record, which
+    happen before this call; this only removes the un-clickable window.
+    """
+    try:
+        from ui.tabs.tab_print import TabPrint
+    except Exception:
+        return
+    monkeypatch.setattr(TabPrint, "_print_native_qt",
+                        lambda self, *a, **k: None, raising=False)
+
+
 # ---------------------------------------------------------------------------
 # The suite never writes into the user's real ChromIQ folder.
 #

--- a/tests/test_report_pdf_layout.py
+++ b/tests/test_report_pdf_layout.py
@@ -82,6 +82,8 @@ def test_table_taller_than_a_page_still_flows(qapp):
 def test_two_straddlers_resolve_independently(qapp):
     """Several sections in sequence: every table ends up on one page with its
     heading, no matter how the earlier pushes shifted the later sections."""
+    from _fontcheck import skip_without_fonts
+    skip_without_fonts()                 # page breaks pivot on real line heights
     section = "<h3>Cube corners</h3>" + f"<table>{_rows(12)}</table>"
     html = ("<p>" + "filler<br>" * 10 + "</p>") + section + section + section
     doc = _doc(html)

--- a/tests/test_verification_print_tab.py
+++ b/tests/test_verification_print_tab.py
@@ -203,6 +203,11 @@ def test_raw_choice_is_recorded_and_prints_unconverted(
     sent: list = []
     monkeypatch.setattr(tab, "_print_pages",
                         lambda pages: sent.append(list(pages)))
+    # Windows forces use_native_print_dialog True (no lp), so _on_print_current
+    # dispatches through _print_native there; capture both so the assertion
+    # holds on whichever path the platform takes.
+    monkeypatch.setattr(tab, "_print_native",
+                        lambda pages: sent.append(list(pages)))
     tab._cm_raw_rb.setChecked(True)
 
     tab._on_print_current()


### PR DESCRIPTION
## Summary

Two beta.221 failures on the Windows 11 ARM64 gate, both **test-only** (no app code). The first is the important one — it **wedged the entire suite**.

## 1. A native print dialog hung the whole gate

`test_verification_print_tab.py` reaches `_on_print_current`, which on Windows dispatches to `TabPrint._print_native_qt` → `QPrintDialog(...).exec()` — a modal with no one to click it, so the headless run hangs forever (it wedged the gate at 98%). `pytest-timeout` under `-n4` never surfaced it; a serial `-n0` run named it immediately.

It reaches that branch on Windows **even though the test sets `use_native_print_dialog` False**, because `AppSettings.get` (`settings.py:909`) *forces* that flag True on Windows (there is no `lp` there). On macOS the same branch takes the driver-native path (`native_print_macos`), not a Qt modal — the classic "passes on Mac, hangs on Windows" shape your `conftest` already guards for the editor render.

**Fix (same place + pattern):** an autouse `conftest` fixture `_no_native_print_dialog` stubs `TabPrint._print_native_qt`, so no test — this batch or future — can wedge on the print modal. One test (`raw` choice) captures print pages via `_print_pages`; it now also captures `_print_native`, matching the both-paths pattern its siblings already use, so its assertion holds on whichever path the platform takes.

## 2. A PDF-layout test measured page breaks against the empty offscreen font DB

`test_report_pdf_layout.py::test_two_straddlers_resolve_independently` asserts a table lands on the same page as its heading — which depends on real line heights. Under offscreen Qt on Windows the font DB is empty (Qt: *"no longer ships fonts"*), so the block lands on the wrong page. Same class as the width guards from #138/#140 → `skip_without_fonts()`.

## Verification

All **22 beta.221 changed test files pass** — `337 passed, 25 skipped, no timeout` — on Windows 11 ARM64 / Python 3.12.10.

> ⚠️ I could **not** complete a full `--runslow -n4` gate on this VM right now: with the host machine busy, the parallel run is CPU-starved and stalls ~⅓ through (even the `pytest-timeout` thread can't get scheduled). The demo cache is warm, so it's **contention, not a rebuild or a code hang** — the serial subset finishes in 15 s, and prior full gates (beta.206) completed in ~9 min when the host was idle. Worth a confirming `--runslow -n4` run when the host frees up; the macOS CI validates cross-platform regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
