### PR TITLE
On Windows a chart restored from a Mac was invisible, and a different one was used in its place

### DIFF
--- a/core/file_manager.py
+++ b/core/file_manager.py
@@ -285,6 +285,31 @@ def nfc(name: str) -> str:
     return unicodedata.normalize("NFC", name)
 
 
+def _has_no_other_spelling(name: str) -> bool:
+    """Whether *name* is the only string that can name this file.
+
+    A name has an alternative spelling only when it is one member of a Unicode
+    canonical-equivalence class with more than one member. Two things put it in
+    such a class, and nothing else does: a character that HAS a canonical
+    decomposition (``ü`` -> ``u`` + U+0308, and every Hangul syllable), or two
+    combining marks that could be written in another order. So a name with no
+    combining marks that NFD leaves alone is alone in its class, and a directory
+    listing could not possibly turn up another spelling of it.
+
+    THIS REPLACED ``str.isascii()``, WHICH WAS THE WRONG QUESTION. It is the
+    right answer for ASCII, but it made every non-ASCII name pay for a listing
+    — and Greek, Turkish, Cyrillic, CJK and emoji names have no other spelling
+    either, so they paid for a scan that could never match (review round 2).
+    ASCII is still checked first because it is a single flag test on the str
+    object, and it is the overwhelming majority.
+    """
+    if name.isascii():
+        return True
+    if any(unicodedata.combining(ch) for ch in name):
+        return False                         # marks: they can be reordered
+    return unicodedata.normalize("NFD", name) == name
+
+
 def resolve_existing(path: Path) -> Path:
     """*path* as this volume really spells it — the accent spelling, and only that.
 
@@ -319,37 +344,52 @@ def resolve_existing(path: Path) -> Path:
     decomposed file IS there, a writer overwrites *it* rather than laying a
     second, identical-looking chart beside it.
 
-    ACCENTS ONLY — case is deliberately untouched. Windows and a default APFS
-    volume are case-insensitive, so ``path.exists()`` has already said yes for a
-    name typed in another case; on a case-SENSITIVE volume two names differing
-    by case are two real files and folding them here would make one stand in for
-    the other. That is :func:`_existing_folder_spelling`'s job, and it does it
-    for folders only, for the same reason.
+    CASE IS FOLDED EXACTLY WHERE THE FILESYSTEM FOLDS IT, and nowhere else —
+    ``_NAME_CASEFOLD``, the same flag :func:`files_matching` uses eighty lines
+    above, so the two cannot drift apart. They did, and it mattered: rename a
+    restored project's folder to another case and the stem arrives upper-case
+    while the file is lower-case AND decomposed. NTFS folds the case but not the
+    accents, so ``exists()`` says no; a comparison that folds the accents but
+    not the case says no as well; and ``stem_files``, which folds both, went on
+    finding the file. The listing saw a chart the accessor did not — this fix
+    switched itself off (review round 2, A-1). Folding here can never conflate
+    two real files, because on the one platform where it is done the filesystem
+    itself refuses to hold two names differing only by case. On Linux, and on a
+    case-SENSITIVE APFS volume, ``_NAME_CASEFOLD`` is False and two such names
+    stay two files.
 
     IT COSTS ONE ``stat`` IN EVERY CASE THAT WORKS TODAY. The hit path is the
     ``exists()`` that was already being paid. The directory listing happens only
-    when the file is genuinely absent under the given spelling AND the name is
-    non-ASCII — an ASCII name has no other spelling to find, because no ASCII
-    character has a canonical decomposition. So on macOS, on Linux, and for
-    every ASCII project name on Windows, this adds one ``str.isascii()`` call
-    and nothing else.
+    when the file is genuinely absent under the given spelling AND the name
+    could have another spelling at all — which is decided by
+    :func:`_has_no_other_spelling`, not by ``str.isascii()``. That mattered: a
+    Greek, Turkish, Cyrillic, CJK or emoji project name is not ASCII and paid
+    for a listing that could never match.
     """
     if path.exists():
         return path                          # the spelling asked for is there
     name = path.name
-    if name.isascii():
-        return path                          # no other spelling can exist
+    if _has_no_other_spelling(name):
+        return path                          # nothing else could be on disk
     want = nfc(name)
+    if _NAME_CASEFOLD:
+        want = want.lower()
     try:
         with os.scandir(str(path.parent)) as entries:
-            same = sorted(e.path for e in entries if nfc(e.name) == want)
+            same = sorted(
+                e.path for e in entries
+                if (nfc(e.name).lower() if _NAME_CASEFOLD else nfc(e.name)) == want)
     except (OSError, ValueError):
         return path                          # unreadable parent: nothing to add
     if not same:
         return path
     if len(same) > 1:
         # Canonically equivalent yet distinct names (combining marks in another
-        # order). Deterministic rather than "whichever the volume listed first".
+        # order). SORTED, so the answer is the same on every call and on every
+        # volume — not "whichever one the directory happened to list first",
+        # which is an ordering neither Python nor the filesystem promises.
+        # `tests/…::test_which_of_several_spellings_wins_is_not_the_listing_order`
+        # feeds the entries in reverse to prove the sort is what decides.
         log.warning("More than one spelling of %s on disk: %s — using %s",
                     name, [Path(p).name for p in same], Path(same[0]).name)
     return Path(same[0])
@@ -378,6 +418,33 @@ def _existing_folder_spelling(parent: Path, name: str) -> str:
     mark, so the two spellings do not compare equal and the loop walks past.
     An explicit NFC guard stood here as well and was removed, because no
     mutation of it could be made to change any outcome.
+
+    AND THE ACCENT CASE IS THEREFORE NOT HANDLED HERE — DELIBERATELY, WITH A
+    KNOWN COST. On a normalisation-sensitive volume (NTFS, ext4) a project whose
+    folder arrived decomposed is NOT found by the composed name the user types
+    into the Create Chart name box, so `working_dir()` points at a folder that
+    does not exist and the next `project()` call CREATES it: two project folders,
+    side by side, spelled differently and drawn identically by every font on the
+    machine. Reproduced on NTFS (review round 2, E-1) and pinned by
+    ``tests/test_a_decomposed_name_finds_its_files.py::
+    test_a_typed_composed_name_does_not_yet_find_a_decomposed_project_folder``
+    so it is a measured fact rather than a surprise.
+
+    Adopting the folder's accent spelling here would fix it and would break
+    something load-bearing: `_sanitise` normalises to NFC (
+    ``test_the_folder_name_is_always_nfc``) and `working_dir` RE-CLEANS the
+    stored target name on every call and compares it to what it stored — so a
+    decomposed `_target_name` would not survive its own round trip, the way a
+    differently-CASED one does (`_sanitise` preserves case, so case is a fixed
+    point and an accent spelling is not). Making it work means changing either
+    the NFC invariant or that compare, and both are pinned behaviour with a
+    documented reason. That is a decision to be taken and reviewed, not one to
+    slip into a bug fix — so it is named here and left.
+
+    Note what this does NOT affect: every route that reaches a project through
+    the FOLDER rather than a typed name — the project picker, `open_project_at`,
+    session restore — takes the folder's own spelling and works today. It is the
+    name box alone.
     """
     if not name:
         return name
@@ -1065,7 +1132,7 @@ class Calibration:
     @property
     def dir(self) -> Path:                    return self._root / "cal"
 
-    def _artefact(self, ext: str) -> Path:
+    def artefact(self, ext: str) -> Path:
         """``cal/<stem><ext>`` as the volume spells it — see
         :func:`resolve_existing`. A calibration restored from a Mac OS Extended
         backup has decomposed file names, and on NTFS a composed path does not
@@ -1073,21 +1140,21 @@ class Calibration:
         return resolve_existing(self.dir / f"{self.stem}{ext}")
 
     @property
-    def cal_path(self) -> Path:               return self._artefact(".cal")
+    def cal_path(self) -> Path:               return self.artefact(".cal")
     @property
-    def ti1(self) -> Path:                    return self._artefact(".ti1")
+    def ti1(self) -> Path:                    return self.artefact(".ti1")
     @property
-    def ti2(self) -> Path:                    return self._artefact(".ti2")
+    def ti2(self) -> Path:                    return self.artefact(".ti2")
     @property
-    def ti3(self) -> Path:                    return self._artefact(".ti3")
+    def ti3(self) -> Path:                    return self.artefact(".ti3")
     @property
-    def icc(self) -> Path:                    return self._artefact(".icc")
+    def icc(self) -> Path:                    return self.artefact(".icc")
     @property
-    def cht(self) -> Path:                    return self._artefact(".cht")
+    def cht(self) -> Path:                    return self.artefact(".cht")
     @property
-    def ps(self) -> Path:                     return self._artefact(".ps")
+    def ps(self) -> Path:                     return self.artefact(".ps")
     @property
-    def channels_json(self) -> Path:          return self._artefact(".channels.json")
+    def channels_json(self) -> Path:          return self.artefact(".channels.json")
     @property
     def meta_path(self) -> Path:              return self.dir / "meta.json"
 
@@ -1631,8 +1698,18 @@ class Run:
     # <stem>.icc), so the whole chart chain shares the project-name stem. The
     # per-run folder removes the need for prefixes/suffixes; reads/ and the
     # role files (merged/preconditioning/calibrated) stay role-named.
-    def _artefact(self, ext: str) -> Path:
+    def artefact(self, ext: str) -> Path:
         """``<run dir>/<stem><ext>`` AS THE VOLUME SPELLS IT.
+
+        PUBLIC, because the fix was incomplete while it was not. A guard that
+        learned to resolve in front of work that still built its own names with
+        an f-string is worse than a guard that stayed shut: it ACTIVATES a code
+        path that was dead, and the path then acts on files that are not there.
+        Two of those shipped in round 1 — `adopt_run_chart_as_verify` orphaned a
+        single-page TIFF, and `workflow.chart_import.archive_run_for_replace`
+        left a whole chart chain unarchived so `chart_cht` answered with the OLD
+        chart's recognition file for the NEW `.ti2`. Anything outside this class
+        that needs `<stem><ext>` asks for it here.
 
         Every named artefact this run owns goes through here, so the accent
         spelling is dealt with once rather than at each of the ~155 places that
@@ -1651,15 +1728,15 @@ class Run:
         return resolve_existing(self.dir / f"{self.stem}{ext}")
 
     @property
-    def chart_ti1(self) -> Path:              return self._artefact(".ti1")
+    def chart_ti1(self) -> Path:              return self.artefact(".ti1")
     @property
-    def chart_ti2(self) -> Path:              return self._artefact(".ti2")
+    def chart_ti2(self) -> Path:              return self.artefact(".ti2")
     @property
-    def chart_cht(self) -> Path:              return self._artefact(".cht")
+    def chart_cht(self) -> Path:              return self.artefact(".cht")
     @property
-    def chart_ps(self) -> Path:               return self._artefact(".ps")
+    def chart_ps(self) -> Path:               return self.artefact(".ps")
     @property
-    def chart_channels_json(self) -> Path:    return self._artefact(".channels.json")
+    def chart_channels_json(self) -> Path:    return self.artefact(".channels.json")
 
     def chart_tiffs(self) -> list[Path]:
         """All chart page bitmaps in this run, sorted.
@@ -1696,7 +1773,7 @@ class Run:
     # (reading ``<stem>.ti2`` produces ``<stem>.ti3``). Per-read averaging
     # snapshots live in reads/readN.ti3 and are averaged back into <stem>.ti3.
     @property
-    def measurement_ti3(self) -> Path:        return self._artefact(".ti3")
+    def measurement_ti3(self) -> Path:        return self.artefact(".ti3")
     @property
     def reads_dir(self) -> Path:              return self.dir / "reads"
 
@@ -1775,7 +1852,7 @@ class Run:
         each site, so it can never be forgotten by one of them — which is how it
         came to be left behind when a re-generation archived the .ti3 it belongs
         to (Knut, #130 2026-07-30)."""
-        return self._artefact(".ti3.engine-partial")
+        return self.artefact(".ti3.engine-partial")
 
     def recoverable_partial_ti3(self) -> "Path | None":
         """The partial measurement when it is the ONLY record of those readings —
@@ -1809,7 +1886,7 @@ class Run:
     # colprof reading <stem>.ti3 writes <stem>.icc (stem-coupled). When a merge
     # ran, the deliverable is merged.icc instead — see built_profile_icc().
     @property
-    def profile_icc(self) -> Path:            return self._artefact(".icc")
+    def profile_icc(self) -> Path:            return self.artefact(".icc")
 
     def built_profile_icc(self) -> Path:
         """The profile a user should treat as the run's output.
@@ -1850,7 +1927,7 @@ class Run:
 
     def _verify_artefact(self, ext: str) -> Path:
         """``verifications/<verify stem><ext>``, spelled as the volume has it —
-        the same rule as :meth:`_artefact`, for the other folder and stem."""
+        the same rule as :meth:`artefact`, for the other folder and stem."""
         return resolve_existing(
             self.verifications_dir / f"{self.verify_stem}{ext}")
 
@@ -1927,7 +2004,7 @@ class Run:
             # path would find none of them — so the chart would be cleared for
             # a move that then moved nothing. The DESTINATION stays composed;
             # it is a name being written, and composed is ChromIQ's spelling.
-            src = self._artefact(ext)
+            src = self.artefact(ext)
             if src.exists():
                 dst = self.verifications_dir / f"{new}{ext}"
                 shutil.move(str(src), str(dst))
@@ -1938,17 +2015,21 @@ class Run:
         # `str.replace` would find nothing and move the page to verifications/
         # still carrying the PROFILING stem — a verify chart with a page the
         # verify glob cannot see.
-        for tif in self.stem_files(old, "_*.tif"):
+        #
+        # BOTH TAILS IN ONE LOOP, AND BOTH THROUGH `stem_files`. A single-page
+        # chart's TIFF has no "_NN" — it is just "<stem>.tif" — and that case
+        # used to be a second block built from a raw f-string. Once the guard at
+        # the top of this method learned to resolve, that block was reached for
+        # the first time on a restored project and could not see the file: the
+        # chart moved into verifications/ and its only page stayed ORPHANED in
+        # the run root, leaving exactly the "pages but no .ti2" contradiction
+        # this change removes everywhere else, and a verify chart that never
+        # previews (Knut #130: "Run type = Verification shows no preview").
+        # Measured, review round 2, defect 1.
+        for tif in self.stem_files(old, "_*.tif", ".tif", ".TIF"):
             dst = self.verifications_dir / nfc(tif.name).replace(nfc(old),
                                                                 nfc(new), 1)
             shutil.move(str(tif), str(dst))
-        # A single-page chart's TIFF has no "_NN" suffix — it's just "<stem>.tif"
-        # — so the glob above misses it. Move that too, or a single-page verify
-        # chart lands in verifications/ with no page bitmap and never previews
-        # (Knut #130: "Run type = Verification shows no preview").
-        single_tif = self.dir / f"{old}.tif"
-        if single_tif.exists():
-            shutil.move(str(single_tif), str(self.verifications_dir / f"{new}.tif"))
         # The chart's hand-off sidecars (exports/) belong with the verify chart.
         exp = self.exports_dir
         if exp.exists():
@@ -2116,7 +2197,11 @@ class Run:
         one-page `.ti2`.
         """
         def _leftovers():
-            return ([self.dir / n for n in self.chart_artefact_names()]
+            # `resolve_existing`, for the same reason as the drop loop in
+            # `reset_chart_artefacts`: a leftover spelled the other way is a
+            # leftover, and this is the sweep that is supposed to catch it.
+            return ([resolve_existing(self.dir / n)
+                     for n in self.chart_artefact_names()]
                     + list(self.chart_tiffs()))
         settle_chart_stash(self.dir, stash, built=built, leftovers=_leftovers)
 
@@ -2161,9 +2246,14 @@ class Run:
         # document them) to old/<timestamp>/ first. Chart files (below) are
         # regenerated, so they may be dropped. Only archives when results exist,
         # so iterating on a not-yet-measured chart doesn't spawn old/ folders.
-        results = [self.dir / f"{s}.ti3", self.partial_ti3,
-                   self.dir / f"{s}.icc",
-                   self.dir / f"{s}.icm", self.dir / "merged.ti3",
+        # THROUGH `artefact`, not an f-string. `partial_ti3` beside these
+        # already resolved, so a restored project archived the engine partial
+        # and left the measurement it belongs to unarchived — and then the drop
+        # loop below could not see it either, so the next build wrote a second
+        # `.ti3` beside it. Same shape as review round 2's two defects.
+        results = [self.artefact(".ti3"), self.partial_ti3,
+                   self.artefact(".icc"),
+                   self.artefact(".icm"), self.dir / "merged.ti3",
                    self.dir / "merged.icc", self.dir / "calibrated.icc"]
         if keep_results:
             results = []
@@ -2211,19 +2301,27 @@ class Run:
             except OSError as exc:
                 log.warning("Could not delete %s: %s", p, exc)
 
-        for name in (
-            f"{s}.ti1", f"{s}.ti2", f"{s}.cht", f"{s}.cie", f"{s}.ps",
-            f"{s}.pdf",                  # vector-PDF export (was left stale, Basti)
-            f"{s}.channels.json", f"{s}.strips.json",
-            f"{s}.print.json",           # how the chart that is GOING was printed
+        # STEM-NAMED ONES THROUGH `artefact`, ROLE-NAMED ONES AS THEY ARE. The
+        # stem side has to resolve or a regenerate leaves the restored chart in
+        # the folder and writes a second one beside it under a name that looks
+        # identical on screen — "two charts under one name", which is the state
+        # `files_matching`'s docstring was written about.
+        stem_exts = (
+            ".ti1", ".ti2", ".cht", ".cie", ".ps",
+            ".pdf",                      # vector-PDF export (was left stale, Basti)
+            ".channels.json", ".strips.json",
+            ".print.json",               # how the chart that is GOING was printed
         ) + ((
-            f"{s}.ti3",                  # the measurement (chartread output)
-            f"{s}.ti3.engine-partial",   # …and the engine partial beside it
-            f"{s}.icc",                  # the profile (colprof output)
+            ".ti3",                      # the measurement (chartread output)
+            ".ti3.engine-partial",       # …and the engine partial beside it
+            ".icc",                      # the profile (colprof output)
+        ) if not keep_results else ())
+        role_named = () if keep_results else (
             "merged.ti3", "merged.icc",  # build-time refinement merge outputs
             "calibrated.icc",            # applycal output
-        ) if not keep_results else ()):
-            p = self.dir / name
+        )
+        for p in ([self.artefact(ext) for ext in stem_exts]
+                  + [self.dir / n for n in role_named]):
             if p.exists():
                 _drop(p)
         for tiff in self.chart_tiffs():
@@ -2683,14 +2781,14 @@ class Project:
             d.name for d in self.runs_root.glob("run*") if d.is_dir()]
         for rid in rids:
             run = Run(self, rid)
-            legacy = run.dir / f"{run.stem}-verify.ti3"
+            legacy = run.artefact("-verify.ti3")
             if not legacy.is_file():
                 continue
             when = datetime.fromtimestamp(legacy.stat().st_mtime)
             v = run.new_verification(when)
             v.ensure_dir()
             self._migrate_move(legacy, v.dir)
-            legacy_ti2 = run.dir / f"{run.stem}-verify.ti2"
+            legacy_ti2 = run.artefact("-verify.ti2")
             if legacy_ti2.is_file():
                 self._migrate_move(legacy_ti2, run.verifications_dir)
 

--- a/core/file_manager.py
+++ b/core/file_manager.py
@@ -285,6 +285,76 @@ def nfc(name: str) -> str:
     return unicodedata.normalize("NFC", name)
 
 
+def resolve_existing(path: Path) -> Path:
+    """*path* as this volume really spells it — the accent spelling, and only that.
+
+    WHY A PATH HAS TO BE RESOLVED AT ALL
+    ------------------------------------
+    ``Path.exists()`` is the filesystem's answer, and the filesystems disagree.
+    macOS (APFS/HFS+) is normalisation-INSENSITIVE, so
+    ``(run.dir / "Müller.ti2").exists()`` is True whether the name on disk is
+    composed or decomposed. **NTFS is normalisation-SENSITIVE, and so is every
+    ordinary Linux volume**: the two spellings are two different names, and one
+    does not find the other. A project that came home from a Mac OS Extended
+    backup therefore holds decomposed file names, and on Windows
+    ``chart_ti2.exists()`` answers False with the chart sitting in the folder —
+    measured on NTFS, not reasoned (``tests/test_a_decomposed_name_finds_its_files.py``).
+
+    :func:`files_matching` already solves this for LISTINGS. This solves it for
+    the single named artefact, which a listing cannot: ``<stem>.ti2`` is one
+    file, asked for by name.
+
+    IT RETURNS A PATH THAT OPENS, WHICH IS THE WHOLE POINT. Answering "yes it
+    is there" and handing back a spelling that ``open()`` then refuses would
+    move the failure rather than fix it, so the *existing* spelling is what
+    comes back — ready to be read, copied or written through.
+
+    THE EXACT SPELLING ALWAYS WINS. The first thing this does is ask for the
+    path it was given; only when that is not there does it look for a name that
+    differs from it by normalisation alone. So when BOTH spellings exist — two
+    genuinely different files on a sensitive volume — the caller gets the one it
+    named, exactly as before, and nothing is ever silently swapped for a
+    neighbour. When neither exists, the path is returned unchanged, so writers
+    still create the canonical (composed) spelling on a fresh run; when a
+    decomposed file IS there, a writer overwrites *it* rather than laying a
+    second, identical-looking chart beside it.
+
+    ACCENTS ONLY — case is deliberately untouched. Windows and a default APFS
+    volume are case-insensitive, so ``path.exists()`` has already said yes for a
+    name typed in another case; on a case-SENSITIVE volume two names differing
+    by case are two real files and folding them here would make one stand in for
+    the other. That is :func:`_existing_folder_spelling`'s job, and it does it
+    for folders only, for the same reason.
+
+    IT COSTS ONE ``stat`` IN EVERY CASE THAT WORKS TODAY. The hit path is the
+    ``exists()`` that was already being paid. The directory listing happens only
+    when the file is genuinely absent under the given spelling AND the name is
+    non-ASCII — an ASCII name has no other spelling to find, because no ASCII
+    character has a canonical decomposition. So on macOS, on Linux, and for
+    every ASCII project name on Windows, this adds one ``str.isascii()`` call
+    and nothing else.
+    """
+    if path.exists():
+        return path                          # the spelling asked for is there
+    name = path.name
+    if name.isascii():
+        return path                          # no other spelling can exist
+    want = nfc(name)
+    try:
+        with os.scandir(str(path.parent)) as entries:
+            same = sorted(e.path for e in entries if nfc(e.name) == want)
+    except (OSError, ValueError):
+        return path                          # unreadable parent: nothing to add
+    if not same:
+        return path
+    if len(same) > 1:
+        # Canonically equivalent yet distinct names (combining marks in another
+        # order). Deterministic rather than "whichever the volume listed first".
+        log.warning("More than one spelling of %s on disk: %s — using %s",
+                    name, [Path(p).name for p in same], Path(same[0]).name)
+    return Path(same[0])
+
+
 def _existing_folder_spelling(parent: Path, name: str) -> str:
     """The name *parent* really holds for *name*, when the two are one folder.
 
@@ -994,22 +1064,30 @@ class Calibration:
 
     @property
     def dir(self) -> Path:                    return self._root / "cal"
+
+    def _artefact(self, ext: str) -> Path:
+        """``cal/<stem><ext>`` as the volume spells it — see
+        :func:`resolve_existing`. A calibration restored from a Mac OS Extended
+        backup has decomposed file names, and on NTFS a composed path does not
+        find them."""
+        return resolve_existing(self.dir / f"{self.stem}{ext}")
+
     @property
-    def cal_path(self) -> Path:               return self.dir / f"{self.stem}.cal"
+    def cal_path(self) -> Path:               return self._artefact(".cal")
     @property
-    def ti1(self) -> Path:                    return self.dir / f"{self.stem}.ti1"
+    def ti1(self) -> Path:                    return self._artefact(".ti1")
     @property
-    def ti2(self) -> Path:                    return self.dir / f"{self.stem}.ti2"
+    def ti2(self) -> Path:                    return self._artefact(".ti2")
     @property
-    def ti3(self) -> Path:                    return self.dir / f"{self.stem}.ti3"
+    def ti3(self) -> Path:                    return self._artefact(".ti3")
     @property
-    def icc(self) -> Path:                    return self.dir / f"{self.stem}.icc"
+    def icc(self) -> Path:                    return self._artefact(".icc")
     @property
-    def cht(self) -> Path:                    return self.dir / f"{self.stem}.cht"
+    def cht(self) -> Path:                    return self._artefact(".cht")
     @property
-    def ps(self) -> Path:                     return self.dir / f"{self.stem}.ps"
+    def ps(self) -> Path:                     return self._artefact(".ps")
     @property
-    def channels_json(self) -> Path:          return self.dir / f"{self.stem}.channels.json"
+    def channels_json(self) -> Path:          return self._artefact(".channels.json")
     @property
     def meta_path(self) -> Path:              return self.dir / "meta.json"
 
@@ -1553,16 +1631,35 @@ class Run:
     # <stem>.icc), so the whole chart chain shares the project-name stem. The
     # per-run folder removes the need for prefixes/suffixes; reads/ and the
     # role files (merged/preconditioning/calibrated) stay role-named.
+    def _artefact(self, ext: str) -> Path:
+        """``<run dir>/<stem><ext>`` AS THE VOLUME SPELLS IT.
+
+        Every named artefact this run owns goes through here, so the accent
+        spelling is dealt with once rather than at each of the ~155 places that
+        ask a ``Run`` for a file. See :func:`resolve_existing`: the exact
+        spelling always wins, an absent file comes back unchanged (so a writer
+        still creates the composed name), and a name normalisation cannot
+        change — every ASCII one — costs a single ``str.isascii()``.
+
+        WHY HERE AND NOT AT THE CALL SITE. ``if run.chart_ti2.exists()`` reads
+        as a question about a file and is one; making every caller ask it a
+        longer way fixes the call sites that exist and not the next one somebody
+        writes — the same argument this module already makes for patterns (see
+        :func:`stem_files`). ``ui/main_window.py:2238`` is why it matters: it
+        did not refuse, it quietly used the ``.ti1`` instead.
+        """
+        return resolve_existing(self.dir / f"{self.stem}{ext}")
+
     @property
-    def chart_ti1(self) -> Path:              return self.dir / f"{self.stem}.ti1"
+    def chart_ti1(self) -> Path:              return self._artefact(".ti1")
     @property
-    def chart_ti2(self) -> Path:              return self.dir / f"{self.stem}.ti2"
+    def chart_ti2(self) -> Path:              return self._artefact(".ti2")
     @property
-    def chart_cht(self) -> Path:              return self.dir / f"{self.stem}.cht"
+    def chart_cht(self) -> Path:              return self._artefact(".cht")
     @property
-    def chart_ps(self) -> Path:               return self.dir / f"{self.stem}.ps"
+    def chart_ps(self) -> Path:               return self._artefact(".ps")
     @property
-    def chart_channels_json(self) -> Path:    return self.dir / f"{self.stem}.channels.json"
+    def chart_channels_json(self) -> Path:    return self._artefact(".channels.json")
 
     def chart_tiffs(self) -> list[Path]:
         """All chart page bitmaps in this run, sorted.
@@ -1599,7 +1696,7 @@ class Run:
     # (reading ``<stem>.ti2`` produces ``<stem>.ti3``). Per-read averaging
     # snapshots live in reads/readN.ti3 and are averaged back into <stem>.ti3.
     @property
-    def measurement_ti3(self) -> Path:        return self.dir / f"{self.stem}.ti3"
+    def measurement_ti3(self) -> Path:        return self._artefact(".ti3")
     @property
     def reads_dir(self) -> Path:              return self.dir / "reads"
 
@@ -1678,7 +1775,7 @@ class Run:
         each site, so it can never be forgotten by one of them — which is how it
         came to be left behind when a re-generation archived the .ti3 it belongs
         to (Knut, #130 2026-07-30)."""
-        return self.dir / f"{self.stem}.ti3.engine-partial"
+        return self._artefact(".ti3.engine-partial")
 
     def recoverable_partial_ti3(self) -> "Path | None":
         """The partial measurement when it is the ONLY record of those readings —
@@ -1712,7 +1809,7 @@ class Run:
     # colprof reading <stem>.ti3 writes <stem>.icc (stem-coupled). When a merge
     # ran, the deliverable is merged.icc instead — see built_profile_icc().
     @property
-    def profile_icc(self) -> Path:            return self.dir / f"{self.stem}.icc"
+    def profile_icc(self) -> Path:            return self._artefact(".icc")
 
     def built_profile_icc(self) -> Path:
         """The profile a user should treat as the run's output.
@@ -1750,17 +1847,24 @@ class Run:
     def verifications_dir(self) -> Path:      return self.dir / VERIFICATIONS_DIRNAME
     @property
     def verify_stem(self) -> str:             return f"{self.stem}-verify"
+
+    def _verify_artefact(self, ext: str) -> Path:
+        """``verifications/<verify stem><ext>``, spelled as the volume has it —
+        the same rule as :meth:`_artefact`, for the other folder and stem."""
+        return resolve_existing(
+            self.verifications_dir / f"{self.verify_stem}{ext}")
+
     @property
-    def verify_chart_ti1(self) -> Path:       return self.verifications_dir / f"{self.verify_stem}.ti1"
+    def verify_chart_ti1(self) -> Path:       return self._verify_artefact(".ti1")
     @property
-    def verify_chart_ti2(self) -> Path:       return self.verifications_dir / f"{self.verify_stem}.ti2"
+    def verify_chart_ti2(self) -> Path:       return self._verify_artefact(".ti2")
     @property
-    def verify_chart_cht(self) -> Path:       return self.verifications_dir / f"{self.verify_stem}.cht"
+    def verify_chart_cht(self) -> Path:       return self._verify_artefact(".cht")
     @property
-    def verify_chart_ps(self) -> Path:        return self.verifications_dir / f"{self.verify_stem}.ps"
+    def verify_chart_ps(self) -> Path:        return self._verify_artefact(".ps")
     @property
     def verify_chart_channels_json(self) -> Path:
-        return self.verifications_dir / f"{self.verify_stem}.channels.json"
+        return self._verify_artefact(".channels.json")
 
     def verify_chart_tiffs(self) -> list[Path]:
         return stem_files(self.verifications_dir, self.verify_stem, "*.tif")
@@ -1818,7 +1922,12 @@ class Run:
         old, new = self.stem, self.verify_stem
         moved_ti2: "Path | None" = None
         for ext in self._CHART_EXTS:
-            src = self.dir / f"{old}{ext}"
+            # `_artefact`, not an f-string: the guard above now passes for a
+            # chart whose files came off an HFS+ volume, and a raw composed
+            # path would find none of them — so the chart would be cleared for
+            # a move that then moved nothing. The DESTINATION stays composed;
+            # it is a name being written, and composed is ChromIQ's spelling.
+            src = self._artefact(ext)
             if src.exists():
                 dst = self.verifications_dir / f"{new}{ext}"
                 shutil.move(str(src), str(dst))
@@ -2160,7 +2269,7 @@ class Verification:
     @property
     def stem(self) -> str:                    return self._run.verify_stem
     @property
-    def measurement_ti3(self) -> Path:        return self.dir / f"{self.stem}.ti3"
+    def measurement_ti3(self) -> Path:        return resolve_existing(self.dir / f"{self.stem}.ti3")
     @property
     def reads_dir(self) -> Path:              return self.dir / "reads"
     @property

--- a/core/run_delete.py
+++ b/core/run_delete.py
@@ -222,7 +222,7 @@ def plan_for(project, target, *, measuring: bool = False
     return DeletePlan(
         kind=KIND_RUN, path=run.dir, run_id=run_id, project_name=name,
         has_measurement=run.measurement_ti3.exists(),
-        has_profile=run.profile_icc.exists() or (run.dir / f"{run.stem}.icm").exists(),
+        has_profile=run.profile_icc.exists() or run.artefact(".icm").exists(),
         archived_measurements=_arch_m, archived_profiles=_arch_p,
         has_chart_snapshot=_has_snapshot(run),
         has_preconditioning=_has_precond(run),

--- a/docs/beta8_open_items.md
+++ b/docs/beta8_open_items.md
@@ -2191,7 +2191,7 @@ came back to it.
 - blocks release: no
 - found by: the Windows ARM64 session's challenge of PR #188
   (`beta 9/staging/12_drift_challenge.md`), re-read here while landing that PR.
-- status: OPEN
+- status: FIXED
 - detail: `tests/test_a_decomposed_name_finds_its_files.py` had never run on
   Windows at all — it called `os.uname()` inside a `skipif`, which is evaluated
   when the decorator is BUILT, so on Windows the whole file failed to collect
@@ -2218,10 +2218,82 @@ came back to it.
   hold a release; but it is a wrong print, not a cosmetic fallback. The other
   two branches are cosmetic: `:2238` falls back to a `.ti1` that shares the
   same defeated stem, so the user gets an honest "no chart".
-- next step: decide whether `Run.chart_ti2` (and its siblings) should resolve
-  through `files_matching`/`nfc` rather than a bare `Path.exists()`, and give
-  the three `main_window` branches the same treatment. Only a Windows machine
-  can prove the fix; nothing here can.
+- fix: **PR #189**, `core.file_manager.resolve_existing(path)` — at the
+  ACCESSOR, not at the three call sites. It returns the spelling the volume
+  really holds, so the path both answers `exists()` and OPENS; a call-site
+  `.exists()` fix would have moved the failure to the `open()` two lines later
+  (`load_rgb_program`, `shutil.copy2`, `note_generated_chart` all USE it).
+  Every stem-named artefact of a `Run`, a `Calibration` and a `Verification`
+  goes through it via the now-public `Run.artefact(ext)` /
+  `Calibration.artefact(ext)`, because ~155 places ask a `Run` for a file and
+  the next one is not written yet. The exact spelling is asked for FIRST, so
+  nothing is ever swapped for a neighbour; an absent file comes back unchanged,
+  so writers still create the composed name; case folds only where
+  `_NAME_CASEFOLD` says the filesystem folds it, the same flag `files_matching`
+  uses eighty lines above. Making the guard truthful then RAN code that had
+  never run on such a project, and two of those paths still built names with
+  f-strings — `adopt_run_chart_as_verify` orphaned a one-page chart's only
+  TIFF in the run root, and `workflow.chart_import.archive_run_for_replace`
+  archived half a chart so `run.chart_cht` handed the scanner the OLD chart's
+  recognition file for the NEW `.ti2`. Both fixed, and the same shape swept for
+  and fixed in six further places (`reset_chart_artefacts`,
+  `settle_chart_stash`'s leftovers, the v3 verification migration,
+  `TabChart._reflect_loaded_project`, the profiling-chart snapshot, and
+  `run_delete`'s `.icm` probe).
+- deliberately NOT fixed, and pinned rather than left unknown: a composed name
+  TYPED into the Create Chart box still does not find a decomposed project
+  FOLDER, so a second, empty, identically-drawn folder is created beside it.
+  Fixing it means changing either the "a folder name is always NFC" invariant
+  or `working_dir`'s re-clean-and-compare, both pinned behaviour with a
+  documented reason — a decision to be taken and reviewed, not slipped into a
+  bug fix. Every route that reaches a project through the FOLDER (the picker,
+  `open_project_at`, session restore) is unaffected and works today.
+- evidence: test_a_named_artefact_resolves_to_the_spelling_that_is_on_disk,
+  test_the_mirror_shape_resolves_too,
+  test_the_ti1_is_not_quietly_substituted_for_a_ti2_that_is_there,
+  test_the_exact_spelling_always_wins_when_both_are_on_disk,
+  test_an_absent_artefact_keeps_its_composed_name_so_a_writer_creates_that,
+  test_a_rewrite_overwrites_the_chart_instead_of_laying_a_second_beside_it,
+  test_case_is_never_folded_by_the_resolver,
+  test_the_whole_chart_chain_and_the_verify_chart_resolve,
+  test_a_calibration_finds_its_own_restored_chart,
+  test_the_ui_resolves_the_restored_chart_and_not_its_ti1,
+  test_a_single_page_verify_chart_takes_its_page_with_it,
+  test_the_multi_page_case_still_works_and_is_not_double_moved,
+  test_a_replace_archives_the_whole_restored_chart_chain,
+  test_a_regenerate_does_not_leave_a_second_chart_under_one_name,
+  test_the_accessor_finds_whatever_the_listing_finds,
+  test_which_of_several_spellings_wins_is_not_the_listing_order,
+  test_a_name_with_no_other_spelling_never_lists_the_directory,
+  test_a_name_that_really_has_another_spelling_is_still_looked_for,
+  test_a_typed_composed_name_does_not_yet_find_a_decomposed_project_folder,
+  test_every_per_chart_sidecar_is_on_both_lists.
+- **the NTFS half is Windows evidence and stays Windows evidence.** The fault,
+  the before/after table (`:2238` resolving `.ti1` 180 patches -> `.ti2` 462
+  patches) and the German on-screen run were produced on the Windows 11 ARM64
+  VM. An independent macOS review (agent BK, 2026-09-05) could not reproduce
+  any of it and did not try to claim otherwise: **macOS cannot hold two
+  canonically equivalent file names in one folder at all** — measured on three
+  disk images made for the purpose, APFS case-insensitive, "Case-sensitive
+  APFS" and macOS's exFAT driver, every one of which folds the pair onto one
+  file. What that review established instead is that the change is a **pure
+  no-op on macOS**: `resolve_existing` was called **6,257 times across a whole
+  `--runslow` gate and returned a path different from the one it was asked for
+  exactly 0 times**, because `Path.exists()` on APFS answers True for the other
+  spelling and the fast path returns before the directory is ever listed. The
+  release gate went 11,213 passed (master) -> 11,246 passed, 0 new failures;
+  the 34-check scanner sweep gave verdict-for-verdict identical results before
+  and after; and driving the real window through chart creation, the Create
+  Chart tab's current-chart panel and the Print tab on both trees produced two
+  borrowed projects byte-identical in all 25 files, `.ti1` and both page TIFFs
+  of a freshly built chart byte-identical, and a `.ti2` differing only in
+  printtarg's `CREATED` timestamp and random `CHART_ID`.
+- one defect was found and fixed IN the PR while landing it:
+  `test_the_exact_spelling_always_wins_when_both_are_on_disk` asserted on the
+  CONTENT of two files that macOS folds into one, so the release gate was red
+  on macOS while green on the machine the branch was written on. The guarantee
+  (the NAME that comes back is the one asked for) is now asserted on every
+  volume and the content check is asked only where there are two files.
 
 ### B8-62 · The CR30 refused the most saturated patches on glossy paper, and called a real reading a truncated reply
 - blocks release: yes

--- a/tests/test_a_decomposed_name_finds_its_files.py
+++ b/tests/test_a_decomposed_name_finds_its_files.py
@@ -474,11 +474,30 @@ def test_the_exact_spelling_always_wins_when_both_are_on_disk(tmp_path):
     On a normalisation-sensitive volume these are two genuinely different
     files. The resolver asks for the path it was GIVEN first, so the answer is
     the one the caller named, exactly as before the fix.
+
+    THE TWO HALVES ARE SPLIT BECAUSE ONE OF THEM CANNOT BE ASKED EVERYWHERE.
+    The NAME that comes back is the guarantee — nothing is swapped for a
+    neighbour — and that is asserted on every volume. The CONTENT can only
+    tell the two files apart where the volume can hold two files: macOS
+    cannot. Measured on three images made for this review — APFS
+    case-insensitive, "Case-sensitive APFS" and exFAT — all three fold the
+    pair onto one file, so the second `write_text` lands on the first and no
+    content assertion here can pass. Written as a single content check, this
+    test was red on macOS in the release gate while green on the NTFS machine
+    it was authored on. Recorded rather than skipped, the way
+    `test_a_typed_composed_name_does_not_yet_find_a_decomposed_project_folder`
+    records the same volume difference — which volume ran it is the
+    interesting half.
     """
     run = _run_at(tmp_path, NAME)
     (run.dir / f"{NAME}.ti2").write_text("composed", encoding="utf-8")
     (run.dir / f"{NFD}.ti2").write_text("decomposed", encoding="utf-8")
     on_disk = [n for n in os.listdir(run.dir) if n.endswith(".ti2")]
+    assert run.chart_ti2.name == f"{NAME}.ti2", (
+        f"the resolver answered with {run.chart_ti2.name!r}, not the spelling "
+        f"it was asked for; {len(on_disk)} .ti2 on disk")
+    if len(on_disk) == 1:
+        return                      # this volume folds; there is no second file
     assert run.chart_ti2.read_text(encoding="utf-8") == "composed", (
         f"the requested spelling must win; {len(on_disk)} .ti2 on disk")
 
@@ -887,7 +906,8 @@ def test_which_of_several_spellings_wins_is_not_the_listing_order(tmp_path,
         (tmp_path / f"{v}.ti2").write_text(v.encode("unicode_escape").decode(),
                                            encoding="utf-8")
     if len([p for p in tmp_path.iterdir() if p.suffix == ".ti2"]) != 2:
-        pytest.skip("this volume folds the two orderings into one file")
+        pytest.skip("this volume folds the two orderings into one file — "
+                    "APFS/HFS+ on macOS does, NTFS does not")
 
     real = fmod.os.scandir
 

--- a/tests/test_a_decomposed_name_finds_its_files.py
+++ b/tests/test_a_decomposed_name_finds_its_files.py
@@ -694,3 +694,329 @@ def test_the_ui_resolves_the_restored_chart_and_not_its_ti1(cal_settings, qapp):
         f"the patch cube would draw {chart.name!r}")
     assert len(tiffs) == 1
     assert MainWindow._current_chart_ti2(_Host(fm, tab)) == ti2
+
+
+# ===========================================================================
+# ROUND 2 — WHAT THE FIRST FIX ACTIVATED
+# ===========================================================================
+#
+# THE SHAPE OF THE WHOLE SECTION, because it is one fault wearing four hats:
+# **the guard learned to resolve and the work behind it did not.** Before
+# `resolve_existing`, `chart_ti2.exists()` was False on NTFS for a restored
+# project, so everything behind that guard was DEAD CODE. Making the guard
+# truthful runs that code for the first time — and it was still building its own
+# names with f-strings and asking bare `.exists()`, so it acts on files that are
+# not there. Fixing a broken guard is exactly when previously-unreachable code
+# runs for the first time, and it is the moment to go and read it.
+#
+# Two of these shipped in round 1 and were found by review, not by me.
+
+
+def _restored_chart(run: Run, *exts: str, pages: int = 0,
+                    single_page: bool = False) -> None:
+    """A chart in *run* spelled the way a Mac OS Extended backup hands it back."""
+    for ext in exts:
+        (run.dir / f"{NFD}{ext}").write_text(f"OLD{ext}", encoding="utf-8")
+    for i in range(1, pages + 1):
+        (run.dir / f"{NFD}_{i:02d}.tif").write_text("page", encoding="utf-8")
+    if single_page:
+        (run.dir / f"{NFD}.tif").write_text("the only page", encoding="utf-8")
+
+
+# ---- DEFECT 1: the single page that stayed behind -------------------------
+
+def test_a_single_page_verify_chart_takes_its_page_with_it(tmp_path):
+    """`adopt_run_chart_as_verify` moved the chart and ORPHANED its only page.
+
+    A one-page chart's TIFF is `<stem>.tif` with no `_NN`, so the `_*.tif` glob
+    misses it and a second block used to catch it — built from a raw f-string,
+    which finds nothing when the file came off an HFS+ volume. On master the
+    outer guard was False and the method did nothing at all; the moment the
+    guard started resolving, this ran for the first time, moved the chart into
+    `verifications/` and left the page in the run root.
+
+    Two things go wrong at once, and both are asserted: the verify chart has no
+    page and never previews (Knut #130, "Run type = Verification shows no
+    preview"), and the run root is left holding a page with no `.ti2` — the very
+    contradiction this whole change removes everywhere else.
+    """
+    run = _run_at(tmp_path, NAME)
+    _restored_chart(run, ".ti1", ".ti2", ".cht", single_page=True)
+
+    moved = run.adopt_run_chart_as_verify()
+    assert moved is not None and moved.is_file()
+
+    assert len(run.verify_chart_tiffs()) == 1, (
+        "the verify chart has no page bitmap, so it never previews")
+    left = [p.name for p in run.dir.iterdir()
+            if p.is_file() and p.name.lower().endswith(".tif")]
+    assert left == [], f"the page was orphaned in the run root: {left}"
+    assert run.chart_tiffs() == [] and not run.chart_ti2.exists(), (
+        "the run root is left in the 'pages but no chart' state")
+
+
+def test_the_multi_page_case_still_works_and_is_not_double_moved(tmp_path):
+    """The `_NN` pages kept working throughout; merging the two blocks into one
+    `stem_files` call must not have changed that, or moved anything twice."""
+    run = _run_at(tmp_path, NAME)
+    _restored_chart(run, ".ti1", ".ti2", pages=3)
+    run.adopt_run_chart_as_verify()
+    assert len(run.verify_chart_tiffs()) == 3
+    assert [p.name for p in run.dir.iterdir() if p.is_file()] == []
+
+
+# ---- DEFECT 2: the chart chain a Replace did not archive ------------------
+
+def test_a_replace_archives_the_whole_restored_chart_chain(tmp_path):
+    """`workflow.chart_import.archive_run_for_replace`, and the worst of the two.
+
+    The `.ti3`, `.icc` and the page TIFFs went through resolving accessors; the
+    `.ti1`, `.ti2` and every `_CHART_EXTS` sidecar were raw f-strings. So a
+    Replace archived half a chart, the new one landed beside what was left, and
+    `run.chart_cht` — which resolves — handed the scanner the OLD chart's
+    recognition file for the NEW `.ti2`. A silent wrong result, and "two charts
+    under one name" produced by the very commit that claims to prevent it.
+    """
+    from workflow.chart_import import archive_run_for_replace
+
+    run = _run_at(tmp_path, NAME)
+    _restored_chart(run, ".ti1", ".ti2", ".cht", ".channels.json", ".cie",
+                    pages=1)
+    (run.dir / f"{NFD}.ti3").write_text("OLD ti3", encoding="utf-8")
+
+    archive = archive_run_for_replace(run, verification=False)
+    assert archive is not None
+    left = sorted(p.name for p in run.dir.iterdir() if p.is_file())
+    assert left == [], f"the Replace left the old chart in place: {left}"
+
+    archived = sorted(p.suffix for p in archive.rglob("*") if p.is_file())
+    for ext in (".ti1", ".ti2", ".cht", ".cie", ".ti3", ".tif"):
+        assert ext in archived, f"{ext} was not archived: {archived}"
+
+    # …and now the new chart is written, composed, as ChromIQ writes it.
+    run.chart_ti2.write_text("NEW ti2", encoding="utf-8")
+    assert not run.chart_cht.exists(), (
+        "chart_cht answers with the OLD chart's recognition file for the NEW "
+        ".ti2 — the scanner would read the wrong chart and say nothing")
+
+
+def test_a_regenerate_does_not_leave_a_second_chart_under_one_name(tmp_path):
+    """`reset_chart_artefacts`, the same shape inside `Run`.
+
+    `partial_ti3` beside these already resolved, so a restored run archived the
+    engine partial and left the measurement it belongs to — and the drop loop
+    could not see the chart either, so the next build wrote a second one.
+    """
+    run = _run_at(tmp_path, NAME)
+    _restored_chart(run, ".ti1", ".ti2", ".cht", ".channels.json", pages=2)
+    (run.dir / f"{NFD}.ti3").write_text("the measurement", encoding="utf-8")
+    (run.dir / f"{NFD}.icc").write_text("the profile", encoding="utf-8")
+
+    run.reset_chart_artefacts()
+    left = sorted(p.name for p in run.dir.iterdir() if p.is_file())
+    assert left == [], f"a regenerate would write beside these: {left}"
+    old = list((run.dir / "old").rglob("*")) if (run.dir / "old").is_dir() else []
+    kept = sorted(p.suffix for p in old if p.is_file())
+    assert ".ti3" in kept and ".icc" in kept, (
+        f"the measurement and the profile must be archived, not dropped: {kept}")
+
+
+# ---- A-1: the resolver and the listing must agree on case -----------------
+
+def test_the_accessor_finds_whatever_the_listing_finds(tmp_path):
+    """The fix must not switch itself off when a folder is renamed by case.
+
+    `files_matching` folds case on Windows (`_NAME_CASEFOLD`) because NTFS does;
+    the resolver did not. So an upper-cased folder over decomposed files left
+    `stem_files` finding the chart and `chart_ti2.exists()` denying it —
+    the fix off, silently, on the platform it was written for.
+
+    ONE-WAY, and deliberately: the accessor may find MORE than the listing (on a
+    case-insensitive APFS volume `exists()` folds case where `Path.glob` does
+    not, and that is the filesystem's answer, not ours). It may never find less.
+    """
+    run = _run_at(tmp_path, NAME.upper())
+    (run.dir / f"{NFD}.ti2").write_text("the chart", encoding="utf-8")
+    if run.stem_files(run.stem, ".ti2"):
+        assert run.chart_ti2.is_file(), (
+            "the listing sees a chart the accessor denies")
+        assert run.chart_ti2.read_text(encoding="utf-8") == "the chart"
+
+
+def test_case_folding_is_still_not_invented_where_the_volume_has_none(tmp_path):
+    """On a case-SENSITIVE volume two names differing by case are two files.
+
+    Asked which it is by writing both and counting, rather than by asking
+    `sys.platform`.
+    """
+    from core.file_manager import resolve_existing
+
+    (tmp_path / "Chart.ti2").write_text("upper", encoding="utf-8")
+    (tmp_path / "chart.ti2").write_text("lower", encoding="utf-8")
+    if len([p for p in tmp_path.iterdir() if p.suffix == ".ti2"]) == 2:
+        assert resolve_existing(tmp_path / "chart.ti2").read_text(
+            encoding="utf-8") == "lower"
+        assert resolve_existing(tmp_path / "Chart.ti2").read_text(
+            encoding="utf-8") == "upper"
+
+
+# ---- M5: the tie-break is the sort, not the directory order ---------------
+
+#: Three spellings of one name, all canonically equivalent, all distinct
+#: strings: the composed form, the decomposed form, and the decomposed form
+#: with its two combining marks written in the other order.
+_TIED = ("ǭ", "ǭ")          # macron-first, ogonek-first
+_TIED_NFC = "ǭ"                                 # ǭ
+
+
+def test_which_of_several_spellings_wins_is_not_the_listing_order(tmp_path,
+                                                                  monkeypatch):
+    """`sorted` is what decides, and dropping it must fail.
+
+    The docstring promises a deterministic answer when a folder holds more than
+    one canonically equivalent spelling. Without this the promise was untested:
+    the entries usually arrive in sorted order anyway, so removing `sorted` left
+    every test green. `os.scandir` is made to hand them back REVERSED, so a
+    version that takes "the first one listed" gets the other file.
+    """
+    import core.file_manager as fmod
+
+    assert all(nfc(v) == _TIED_NFC for v in _TIED), "the premise of this test"
+    assert len(set(_TIED)) == 2
+    for v in _TIED:
+        (tmp_path / f"{v}.ti2").write_text(v.encode("unicode_escape").decode(),
+                                           encoding="utf-8")
+    if len([p for p in tmp_path.iterdir() if p.suffix == ".ti2"]) != 2:
+        pytest.skip("this volume folds the two orderings into one file")
+
+    real = fmod.os.scandir
+
+    class _Reversed:
+        def __init__(self, path):
+            self._entries = list(real(path))[::-1]
+
+        def __enter__(self):
+            return iter(self._entries)
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(fmod.os, "scandir", _Reversed)
+    got = fmod.resolve_existing(tmp_path / f"{_TIED_NFC}.ti2")
+    assert got.name == f"{min(_TIED)}.ti2", (
+        f"the listing order decided, not the sort: got {got.name!r}")
+    # …and it is the same answer every time it is asked.
+    assert {fmod.resolve_existing(tmp_path / f"{_TIED_NFC}.ti2").name
+            for _ in range(5)} == {got.name}
+
+
+# ---- the cheap exit is about spellings, not about ASCII -------------------
+
+@pytest.mark.parametrize("stem", [
+    "Δοκιμη-χαρτι",   # Greek, unaccented
+    "Проба-печати",        # Cyrillic, no marks
+    "テスト-用紙",           # Japanese
+    "打印测试",             # Chinese
+    "Test-📄-chart",        # emoji
+    "Yazıcı-testi",        # Turkish dotless i
+])
+def test_a_name_with_no_other_spelling_never_lists_the_directory(
+        tmp_path, monkeypatch, stem):
+    """`str.isascii()` was the wrong question.
+
+    It is the right ANSWER for ASCII, but it made every non-ASCII name pay for
+    a directory scan that could not possibly match — a name has another spelling
+    only if something in it decomposes or if two combining marks could be
+    reordered, and none of these has either.
+    """
+    import core.file_manager as fmod
+
+    assert not stem.isascii(), "this test is about the non-ASCII fast exit"
+
+    def _explode(*a, **k):
+        raise AssertionError(f"scandir called for {stem!r}, which has no "
+                             "other spelling")
+
+    monkeypatch.setattr(fmod.os, "scandir", _explode)
+    missing = tmp_path / f"{stem}.ti2"
+    assert fmod.resolve_existing(missing) == missing
+
+
+@pytest.mark.parametrize("stem", [
+    NAME,                        # composes: ü -> u + U+0308
+    NFD,                         # already decomposed
+    "한글-chart",        # Hangul: every syllable decomposes
+    "ǭ-chart",       # two marks that could be reordered
+    # Greek WITH accents: ή is U+03AE and decomposes to η + U+0301. This test
+    # is where it belongs — the first version of the list above had it as a
+    # name with "no other spelling", and the assertion caught that, which is
+    # the whole reason the pair of tests exists.
+    "Δοκιμή-χαρτί",
+])
+def test_a_name_that_really_has_another_spelling_is_still_looked_for(
+        tmp_path, monkeypatch, stem):
+    """The other half, or the cheap exit would silently switch the fix off.
+
+    A guard that skips too much is the same bug wearing the opposite sign, so
+    the scan is asserted to HAPPEN for every name that could have a twin.
+    """
+    import core.file_manager as fmod
+
+    seen: list[str] = []
+    real = fmod.os.scandir
+
+    def _noted(path):
+        seen.append(str(path))
+        return real(path)
+
+    monkeypatch.setattr(fmod.os, "scandir", _noted)
+    fmod.resolve_existing(tmp_path / f"{stem}.ti2")
+    assert seen, f"{stem!r} has another spelling and was not looked for"
+
+
+# ---- E-1: named, measured, and NOT fixed here ----------------------------
+
+def test_a_typed_composed_name_does_not_yet_find_a_decomposed_project_folder(
+        tmp_path, monkeypatch):
+    """A KNOWN GAP, PINNED SO IT IS A FACT RATHER THAN A SURPRISE.
+
+    Every route that reaches a project through the FOLDER — the picker,
+    `open_project_at`, session restore — takes the folder's own spelling and
+    works. The Create Chart NAME BOX does not: `_sanitise` normalises to NFC,
+    `_existing_folder_spelling` adopts a differently-CASED folder but
+    deliberately not a differently-ACCENTED one, and on NTFS the composed path
+    simply is not there — so `project()` creates a SECOND, empty folder that is
+    drawn identically to the first by every font on the machine.
+
+    It is not fixed here because fixing it means changing either the "a folder
+    name is always NFC" invariant or `working_dir`'s re-clean-and-compare, both
+    of which are pinned behaviour with a documented reason
+    (`test_project_name_keeps_its_accents`). See `_existing_folder_spelling`'s
+    docstring. **This test asserts what ChromIQ does today, not what it should
+    do** — when that decision is taken, this test is the one to change.
+    """
+    from core.file_manager import FileManager
+    from core.settings import AppSettings
+
+    monkeypatch.setenv("CHROMIQ_SETTINGS_FILE", str(tmp_path / "s.ini"))
+    work = tmp_path / "work"
+    work.mkdir()
+    Project.create(work / NFD, NFD)
+
+    s = AppSettings()
+    s.set("custom_output_path", str(work))
+    fm = FileManager(s)
+    fm.set_target_name(NAME)                 # the user TYPES the composed name
+    fm.project()
+
+    folders = sorted(p.name for p in work.iterdir() if p.is_dir())
+    if len(folders) == 1:
+        # A normalisation-INSENSITIVE volume (APFS) folds the two spellings
+        # into one folder, so the gap cannot happen there. Recorded, not
+        # skipped — which volume ran this is the interesting half.
+        assert nfc(folders[0]) == NAME
+        return
+    assert set(folders) == {NFD, NAME}, folders
+    assert list((work / NAME).glob("**/*.ti2")) == [], (
+        "the new folder is the empty one — the user's chart is in the "
+        "other, and the two are drawn identically by every font")

--- a/tests/test_a_decomposed_name_finds_its_files.py
+++ b/tests/test_a_decomposed_name_finds_its_files.py
@@ -367,3 +367,330 @@ def test_the_app_finds_the_chart_after_that_round_trip(tmp_path, monkeypatch):
     if IS_MACOS:                             # the premise — see above
         assert found.chart_ti2.exists()
     assert len(found.chart_tiffs()) == 4, [p.name for p in found.chart_tiffs()]
+
+
+# ===========================================================================
+# B8-61 — THE NAMED ARTEFACT, which a listing cannot answer
+# ===========================================================================
+#
+# Everything above is about a LISTING: "which files in this folder are pages of
+# that chart". `files_matching` answers that on the composed spelling of both
+# sides, and has done since the HFS+ round trip was measured.
+#
+# `<stem>.ti2` is not a listing. It is one file, asked for by name, through
+# `Path.exists()` — and `Path.exists()` is the FILESYSTEM's answer, so it
+# differs by filesystem. APFS/HFS+ fold the two spellings, which is why the
+# tests above guard their premise behind `IS_MACOS`. **NTFS does not**, and
+# neither does an ordinary Linux volume: measured on a Windows 11 ARM64 NTFS
+# machine, `run.chart_ti2.exists()` answered False with the chart in the folder,
+# and `ui/main_window.py:2238` then silently used the `.ti1` instead — a
+# different chart, with no message of any kind.
+#
+# `core.file_manager.resolve_existing` is the fix, and every `Run` /
+# `Calibration` / `Verification` artefact goes through it. These tests are
+# written so they MEAN SOMETHING ON WINDOWS: not one is guarded by platform, and
+# on a normalisation-insensitive volume each still asserts a true thing (it
+# passes for the filesystem's reason rather than the resolver's).
+
+
+def _volume_folds_spellings(tmp_path) -> bool:
+    """Whether THIS volume answers `exists()` across the two spellings.
+
+    Measured, never assumed from `sys.platform`: an APFS volume folds, an NTFS
+    one does not, and ChromIQ runs on external volumes of both kinds.
+    """
+    probe = tmp_path / f"{NFD}.probe"
+    probe.write_text("x", encoding="utf-8")
+    try:
+        return (tmp_path / f"{NAME}.probe").exists()
+    finally:
+        probe.unlink()
+
+
+def _run_at(root: Path, folder_name: str) -> Run:
+    """A `Run` under `<root>/<folder_name>/runs/run1`, folder created."""
+    d = root / folder_name / "runs" / "run1"
+    d.mkdir(parents=True, exist_ok=True)
+    return Run.for_dir(d)
+
+
+def test_a_named_artefact_resolves_to_the_spelling_that_is_on_disk(tmp_path):
+    """The fault, at the accessor: a composed stem and a decomposed file.
+
+    This is a project ChromIQ created (composed folder) into which a chart was
+    restored from a Mac OS Extended backup (decomposed files) — the ordinary
+    way a chart comes home, and the shape measured on NTFS.
+    """
+    run = _run_at(tmp_path, NAME)                                      # stem NFC
+    (run.dir / f"{NFD}.ti2").write_text("the .ti2", encoding="utf-8")  # file NFD
+    assert run.stem == NAME
+
+    assert run.chart_ti2.exists(), (
+        "the chart is in the folder and the app cannot see it")
+    assert run.chart_ti2.is_file()
+    # AND IT OPENS. An accessor that says "yes it is there" and hands back a
+    # spelling `open()` refuses would move the failure, not fix it.
+    assert run.chart_ti2.read_text(encoding="utf-8") == "the .ti2"
+
+
+def test_the_mirror_shape_resolves_too(tmp_path):
+    """A DECOMPOSED folder holding files ChromIQ or a zip wrote composed.
+
+    The stem comes from the folder, so this is the same fault with the two
+    spellings swapped — the shape a Windows user hits after copying a project
+    folder off a Mac and importing a chart into it.
+    """
+    run = _run_at(tmp_path, NFD)
+    (run.dir / f"{NAME}.ti2").write_text("the .ti2", encoding="utf-8")
+    assert run.stem == NFD
+    assert run.chart_ti2.read_text(encoding="utf-8") == "the .ti2"
+
+
+def test_the_ti1_is_not_quietly_substituted_for_a_ti2_that_is_there(tmp_path):
+    """`ui/main_window.py:2238`, which is why this is a data fault:
+
+        chart = run.chart_ti2 if run.chart_ti2.exists() else run.chart_ti1
+
+    It does not refuse and it does not warn. On NTFS the `.ti2` "did not
+    exist", so the user got the `.ti1` — a different, unlaid-out chart —
+    presented as the current one. Both files are put on disk here, spelled
+    differently, so a substitution is DETECTABLE rather than inferred.
+    """
+    run = _run_at(tmp_path, NFD)
+    (run.dir / f"{NFD}.ti1").write_text("the .ti1 — the WRONG chart",
+                                        encoding="utf-8")
+    (run.dir / f"{NAME}.ti2").write_text("the .ti2 — the right chart",
+                                         encoding="utf-8")
+
+    chart = run.chart_ti2 if run.chart_ti2.exists() else run.chart_ti1
+    assert chart.name.endswith(".ti2"), (
+        f"the app used {chart.name!r} — a different chart, silently")
+    assert chart.read_text(encoding="utf-8").endswith("the right chart")
+
+
+def test_the_exact_spelling_always_wins_when_both_are_on_disk(tmp_path):
+    """Two files, two spellings, one requested — nothing is swapped.
+
+    On a normalisation-sensitive volume these are two genuinely different
+    files. The resolver asks for the path it was GIVEN first, so the answer is
+    the one the caller named, exactly as before the fix.
+    """
+    run = _run_at(tmp_path, NAME)
+    (run.dir / f"{NAME}.ti2").write_text("composed", encoding="utf-8")
+    (run.dir / f"{NFD}.ti2").write_text("decomposed", encoding="utf-8")
+    on_disk = [n for n in os.listdir(run.dir) if n.endswith(".ti2")]
+    assert run.chart_ti2.read_text(encoding="utf-8") == "composed", (
+        f"the requested spelling must win; {len(on_disk)} .ti2 on disk")
+
+
+def test_an_absent_artefact_keeps_its_composed_name_so_a_writer_creates_that(
+        tmp_path):
+    """Nothing on disk: the path comes back untouched.
+
+    That is what keeps ChromIQ writing the composed spelling on a fresh run —
+    the fix must not become "normalise names at creation time", which would
+    leave every project already on disk spelled the old way.
+    """
+    run = _run_at(tmp_path, NAME)
+    assert run.chart_ti2 == run.dir / f"{NAME}.ti2"
+    assert run.chart_ti1 == run.dir / f"{NAME}.ti1"
+    assert run.profile_icc == run.dir / f"{NAME}.icc"
+
+
+def test_a_rewrite_overwrites_the_chart_instead_of_laying_a_second_beside_it(
+        tmp_path):
+    """The write side, and the reason resolving beats "check at the call site".
+
+    Writing through an unresolved composed path onto a folder holding the
+    decomposed one leaves TWO .ti2 files with names that look identical on
+    screen — "two charts under one name", the state `files_matching`'s
+    docstring was written about.
+    """
+    run = _run_at(tmp_path, NAME)
+    (run.dir / f"{NFD}.ti2").write_text("v1", encoding="utf-8")
+    run.chart_ti2.write_text("v2", encoding="utf-8")
+    ti2s = [n for n in os.listdir(run.dir) if n.endswith(".ti2")]
+    assert len(ti2s) == 1, f"a second chart was laid beside the first: {ti2s}"
+    assert run.chart_ti2.read_text(encoding="utf-8") == "v2"
+
+
+def test_case_is_never_folded_by_the_resolver(tmp_path):
+    """Accents only. Two names differing by case are two files on a
+    case-sensitive volume, and folding them here would make one stand in for
+    the other — the fault `_existing_folder_spelling` is careful to avoid for
+    folders, for the same reason."""
+    from core.file_manager import resolve_existing
+
+    (tmp_path / "Chart.ti2").write_text("upper", encoding="utf-8")
+    got = resolve_existing(tmp_path / "chart.ti2")
+    assert got.name == "chart.ti2", (
+        "the resolver adopted another case; only the accent spelling is its "
+        "business")
+
+
+def test_an_ascii_name_never_lists_the_directory(tmp_path, monkeypatch):
+    """The cost guarantee, asserted rather than claimed.
+
+    No ASCII character has a canonical decomposition, so an ASCII name has no
+    other spelling to look for. Every project name in this suite, and the
+    overwhelming majority of real ones, takes one `stat` and stops — which is
+    exactly what it cost before the fix.
+    """
+    import core.file_manager as fmod
+
+    def _explode(*a, **k):
+        raise AssertionError("scandir called for an ASCII name")
+
+    monkeypatch.setattr(fmod.os, "scandir", _explode)
+    missing = tmp_path / "Canon-PRO-300.ti2"
+    assert fmod.resolve_existing(missing) == missing
+
+
+def test_a_hit_never_lists_the_directory_either(tmp_path, monkeypatch):
+    """An accented name whose exact spelling IS on disk — the macOS case, and
+    every chart ChromIQ wrote itself — also stops at the first `stat`."""
+    import core.file_manager as fmod
+
+    (tmp_path / f"{NAME}.ti2").write_text("x", encoding="utf-8")
+
+    def _explode(*a, **k):
+        raise AssertionError("scandir called when the exact spelling was there")
+
+    monkeypatch.setattr(fmod.os, "scandir", _explode)
+    assert fmod.resolve_existing(tmp_path / f"{NAME}.ti2").is_file()
+
+
+def test_an_unreadable_parent_is_the_path_unchanged_not_an_exception(tmp_path):
+    """A resolver that raises where `exists()` used to answer False would turn
+    a missing chart into a crash."""
+    from core.file_manager import resolve_existing
+
+    p = tmp_path / "nowhere" / f"{NAME}.ti2"
+    assert resolve_existing(p) == p
+    a_file = tmp_path / "a-file"
+    a_file.write_text("x", encoding="utf-8")
+    q = a_file / f"{NAME}.ti2"
+    assert resolve_existing(q) == q
+
+
+def test_the_whole_chart_chain_and_the_verify_chart_resolve(tmp_path):
+    """Not just the `.ti2`. A run whose `.ti2` is found and whose `.cht` is not
+    is a run that half works — scanin would refuse a chart the tab shows."""
+    run = _run_at(tmp_path, NAME)
+    for ext in (".ti1", ".ti2", ".cht", ".ps", ".channels.json", ".ti3", ".icc"):
+        (run.dir / f"{NFD}{ext}").write_text(ext, encoding="utf-8")
+    for got in (run.chart_ti1, run.chart_ti2, run.chart_cht, run.chart_ps,
+                run.chart_channels_json, run.measurement_ti3, run.profile_icc):
+        assert got.is_file(), f"{got.name} not found"
+
+    vdir = run.verifications_dir
+    vdir.mkdir(parents=True)
+    vstem = ud.normalize("NFD", run.verify_stem)
+    for ext in (".ti1", ".ti2", ".cht"):
+        (vdir / f"{vstem}{ext}").write_text(ext, encoding="utf-8")
+    assert run.has_verify_chart(), "the verify chart is there and unseen"
+    assert run.verify_chart_ti2.is_file() and run.verify_chart_ti1.is_file()
+    assert run.verify_chart_cht.is_file()
+
+
+def test_a_calibration_finds_its_own_restored_chart(tmp_path):
+    """`cal/` is stem-named too, and a calibration comes home from the same
+    backup as the project it belongs to."""
+    proj = Project.create(tmp_path / NAME, NAME)
+    cal = proj.calibration
+    cal.dir.mkdir(parents=True, exist_ok=True)
+    cstem = ud.normalize("NFD", cal.stem)
+    for ext in (".ti1", ".ti2", ".ti3", ".cal", ".icc"):
+        (cal.dir / f"{cstem}{ext}").write_text(ext, encoding="utf-8")
+    for got in (cal.ti1, cal.ti2, cal.ti3, cal.cal_path, cal.icc):
+        assert got.is_file(), f"{got.name} not found"
+
+
+def test_adopting_a_restored_chart_as_a_verify_chart_moves_it(tmp_path):
+    """The guard and the move have to agree.
+
+    `adopt_run_chart_as_verify` clears the old verify chart and THEN moves the
+    new one. Its guard is `chart_ti2.exists()`; the move was a raw f-string. A
+    guard that now passes over a move that still cannot see the files would
+    clear a chart for a move that moves nothing.
+    """
+    run = _run_at(tmp_path, NAME)
+    for ext in (".ti1", ".ti2", ".cht"):
+        (run.dir / f"{NFD}{ext}").write_text(ext, encoding="utf-8")
+    moved = run.adopt_run_chart_as_verify()
+    assert moved is not None and moved.is_file(), (
+        "the guard passed and the move moved nothing")
+    assert moved.read_text(encoding="utf-8") == ".ti2"
+    assert run.verify_chart_ti1.is_file() and run.verify_chart_cht.is_file()
+    left = [n for n in os.listdir(run.dir)
+            if n.endswith((".ti1", ".ti2", ".cht"))]
+    assert left == [], f"left behind under the profiling stem: {left}"
+
+
+def test_the_volume_this_ran_on_is_recorded_rather_than_assumed(tmp_path):
+    """Not an assertion about the fix — a RECORD of which filesystem ran it.
+
+    On a folding volume the tests above pass for the filesystem's reason; on a
+    sensitive one they pass for the resolver's. Which it was is worth knowing
+    when a failure is read months later, so it is measured and printed rather
+    than inferred from `sys.platform`.
+    """
+    folds = _volume_folds_spellings(tmp_path)
+    if IS_MACOS:
+        assert folds, "a Mac volume that does not fold spellings — say so"
+    print(f"\nnormalisation-insensitive volume: {folds} "
+          f"(sys.platform={sys.platform})")
+
+
+# ---------------------------------------------------------------------------
+# Through the real UI resolution — the path `ui/main_window.py:2238` takes
+# ---------------------------------------------------------------------------
+
+def test_the_ui_resolves_the_restored_chart_and_not_its_ti1(cal_settings, qapp):
+    """`TabChart._resolve_target_chart`, which is what `:2238` asks.
+
+    The offscreen GUARD for the on-screen proof: an NFD-named project whose
+    `.ti2` is spelled composed and whose `.ti1` is spelled like the folder, so
+    the substitution has somewhere to go. A `MainWindow` cannot be built under
+    `QT_QPA_PLATFORM=offscreen` without segfaulting, so this drives the real
+    `TabChart` + `FileManager` through the same duck-typed host
+    `tests/test_patch_set_editor_opens_the_selected_target.py` uses.
+    """
+    from core.argyll_runner import ArgyllRunner
+    from core.measurement_target import RUN_TYPE_PROFILING
+    from ui.main_window import MainWindow
+    from ui.measurement_target_bar import MeasurementTargetController
+    from ui.tabs.tab_chart import TabChart
+
+    class _Host:
+        def __init__(self, fm, tab):
+            self._file_mgr, self._tab_chart = fm, tab
+
+    fm = FileManager(cal_settings)
+    fm.open_project_at(Path(cal_settings.get("custom_output_path")) / NFD)
+    proj = fm.project()
+    run = proj.current_run()
+    assert run.stem == NFD, run.stem
+
+    (run.dir / f"{NFD}.ti1").write_text("the .ti1 — the WRONG chart",
+                                        encoding="utf-8")
+    (run.dir / f"{NAME}.ti2").write_text("the .ti2 — the right chart",
+                                         encoding="utf-8")
+    (run.dir / f"{NAME}_01.tif").write_text("page", encoding="utf-8")
+
+    tab = TabChart(ArgyllRunner(cal_settings), fm, cal_settings)
+    ctl = MeasurementTargetController(fm)
+    tab.set_target_controller(ctl)
+    ctl.set_run_type(RUN_TYPE_PROFILING)
+    ctl.set_profile_run(run.id)
+
+    resolved = tab._resolve_target_chart()
+    assert resolved is not None, (
+        "the tab found no chart at all — 'No chart for this profile run yet' "
+        "with the chart in the folder")
+    ti2, tiffs, ti1 = resolved
+    chart = ti2 if ti2.exists() else ti1          # the `:2238` expression
+    assert chart.read_text(encoding="utf-8").endswith("the right chart"), (
+        f"the patch cube would draw {chart.name!r}")
+    assert len(tiffs) == 1
+    assert MainWindow._current_chart_ti2(_Host(fm, tab)) == ti2

--- a/tests/test_a_regenerated_chart_keeps_no_print_record.py
+++ b/tests/test_a_regenerated_chart_keeps_no_print_record.py
@@ -173,6 +173,16 @@ def test_every_per_chart_sidecar_is_on_both_lists(tmp_path):
     `.channels.json` (how many inks and in what order), `.strips.json` (where
     the strips are on the sheet) and `.print.json` (how the sheet was
     printed). All three describe THAT chart, so all three go when it goes.
+
+    THE WIPE LIST IS SPELLED IN EXTENSIONS NOW, NOT IN WHOLE NAMES. It used
+    to read `f"{s}.channels.json"`; it reads `".channels.json"` and goes
+    through `Run.artefact`, because a name built by interpolation is a name
+    the filesystem may not hold — on NTFS a chart restored from a Mac OS
+    Extended backup is spelled decomposed, the interpolated name found none
+    of it, and a regenerate left the old chart in the folder while writing a
+    second one beside it (B8-61). What this test is ABOUT is unchanged and
+    still checked: the sidecar must be on BOTH lists. Only the spelling it
+    looks for moved.
     """
     import inspect
 
@@ -183,7 +193,11 @@ def test_every_per_chart_sidecar_is_on_both_lists(tmp_path):
     wipe = inspect.getsource(Run.reset_chart_artefacts)
     for sidecar in (".channels.json", ".strips.json", ".print.json"):
         assert f"{run.stem}{sidecar}" in names, f"{sidecar} is not an artefact"
-        assert f'{{s}}{sidecar}"' in wipe, f"{sidecar} is not wiped"
+        assert f'"{sidecar}"' in wipe, f"{sidecar} is not wiped"
+    # …and the wipe really goes through the resolver, or the list above is
+    # a list of names nothing looks for.
+    assert "self.artefact(ext)" in wipe, (
+        "the wipe builds its own paths again; a decomposed chart survives it")
 
 
 def test_a_chart_adopted_as_a_verify_chart_takes_its_record_along(tmp_path):

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1574,6 +1574,10 @@ class MainWindow(QMainWindow):
                 return
             run = proj.run(run_id)
             tiffs = run.chart_tiffs()
+            # `chart_tiffs()` has always matched on the composed spelling of
+            # both sides; `chart_ti2.exists()` did not, so on NTFS this returned
+            # early with four page bitmaps in hand and refused to show the
+            # duplicate it had just made. Both halves agree now (B8-61).
             if not run.chart_ti2.exists() or not tiffs:
                 return              # nothing to show; the copy is still real
             source_id = (run.load_meta().duplicated_from or "")
@@ -2229,6 +2233,16 @@ class MainWindow(QMainWindow):
         # building Knut's tool-availability table, which is exactly the kind of
         # thing that table is meant to surface. Resolve through the one method
         # that knows all three run types, and fall back to the .ti1 as before.
+        # THE `.ti1` FALLBACK IS A SUBSTITUTION, SO THE `.exists()` HAS TO BE
+        # TRUE. This branch does not refuse and does not warn — it quietly draws
+        # a different chart's cube under the label "Current chart". On NTFS that
+        # made it wrong for real: a project restored from a Mac OS Extended
+        # backup has decomposed file names, `<stem>.ti2` composed is not there
+        # as far as NTFS is concerned, and the `.ti1` it fell back to was not
+        # there either (measured on this machine, B8-61). `Run.chart_ti2` now
+        # answers with the spelling the volume actually holds — see
+        # `core.file_manager.resolve_existing` — so `.exists()` here is the
+        # question it always read as, and the path it returns opens.
         resolved = self._tab_chart._resolve_target_chart()
         if resolved:
             ti2, _tiffs, ti1 = resolved
@@ -2862,7 +2876,10 @@ class MainWindow(QMainWindow):
             self._tab_print.load_tiffs(tiffs)
             # A LOADED chart must carry its .ti2 into the Print tab too —
             # an already-converted chart forces Raw only if the tab knows
-            # which chart it is holding (§3.1a; Basti, 2026-08-10).
+            # which chart it is holding (§3.1a; Basti, 2026-08-10). The pages
+            # above are found by spelling-insensitive matching, so this had to
+            # be as well or a restored project printed its chart as if nobody
+            # knew what it was (B8-61).
             if run.chart_ti2.exists():
                 self._tab_print.note_generated_chart(run.chart_ti2)
 

--- a/ui/tabs/tab_chart.py
+++ b/ui/tabs/tab_chart.py
@@ -16128,8 +16128,13 @@ class TabChart(QWidget):
             else:
                 ti2, ti1 = run.chart_ti2, run.chart_ti1
                 tiffs = run.stem_files(run.stem, "_*.tif")
-                if not tiffs and (run.dir / f"{run.stem}.tif").is_file():
-                    tiffs = [run.dir / f"{run.stem}.tif"]
+                if not tiffs:
+                    # printtarg writes a ONE-page chart as `<stem>.tif`, with no
+                    # `_NN`. Through `stem_files` rather than an f-string, so a
+                    # single-page chart restored from a Mac OS Extended volume
+                    # is found too — the raw path here was composed and the file
+                    # on disk decomposed, and the tab said there was no chart.
+                    tiffs = run.stem_files(run.stem, ".tif", ".TIF")
             if ti2.is_file() and tiffs:
                 return ti2, list(tiffs), ti1
         except Exception as exc:  # noqa: BLE001 — never break the tab on this

--- a/ui/tabs/tab_chart.py
+++ b/ui/tabs/tab_chart.py
@@ -6218,8 +6218,11 @@ class TabChart(QWidget):
             run = self._file_mgr.project().current_run()
             ti2 = run.chart_ti2
             tiffs = run.stem_files(run.stem, "_*.tif")
-            if not tiffs and (run.dir / f"{run.stem}.tif").is_file():
-                tiffs = [run.dir / f"{run.stem}.tif"]
+            if not tiffs:
+                # The one-page chart, through `stem_files` — a raw composed
+                # path finds nothing in a project restored from a Mac backup,
+                # and `ti2` beside it resolves, so the pair disagreed.
+                tiffs = run.stem_files(run.stem, ".tif", ".TIF")
         except Exception as exc:  # noqa: BLE001 — never block on a malformed run
             log.warning("Could not read loaded project's current run: %s", exc)
             ti2, tiffs = None, []
@@ -6227,7 +6230,7 @@ class TabChart(QWidget):
         self._log.appendPlainText(
             tr("Loaded profile “{name}”.").format(name=self._last_target_name))
         if tiffs:
-            ti1 = run.dir / f"{run.stem}.ti1"
+            ti1 = run.chart_ti1          # resolves; `ti2` above already does
             self._display_run_chart(ti2, tiffs, ti1)
         else:
             self._preview.clear()
@@ -15921,8 +15924,14 @@ class TabChart(QWidget):
             run = self._file_mgr.project().current_run()
         except Exception:      # noqa: BLE001
             return None
+        # THE SAFETY NET HAS TO SEE THE FILES IT IS SAVING. Built from a raw
+        # f-string, this snapshot silently found nothing for a chart restored
+        # from a Mac backup — and it is what puts the profiling chart back after
+        # a verification build has archived it. Now that
+        # `adopt_run_chart_as_verify` actually moves such a chart, an empty
+        # snapshot would mean the run really did lose its profile.
         stem = run.stem
-        srcs = [run.dir / f"{stem}{ext}" for ext in
+        srcs = [run.artefact(ext) for ext in
                 (".ti1", ".ti2", ".cht", ".channels.json", ".strips.json",
                  ".tif", ".ti3", ".icc", ".icm")]
         srcs += run.stem_files(stem, "_*.tif")

--- a/workflow/chart_import.py
+++ b/workflow/chart_import.py
@@ -101,11 +101,20 @@ def archive_run_for_replace(run: Run, *, verification: bool) -> "Path | None":
                              if p.is_file()
                              and p.name not in CHART_SIDE_FILES]
         return run.archive_to_old(paths, into=run.verifications_old_dir)
-    s = run.stem
-    paths = [run.dir / f"{s}.ti1", run.dir / f"{s}.ti2"]
-    paths += [run.dir / f"{s}{ext}" for ext in _CHART_EXTS]
+    # `run.artefact`, NOT an f-string. A Replace archives what it displaces and
+    # then the new chart is written beside it — so a chain this list cannot see
+    # is a chain that stays. On a project restored from a Mac OS Extended
+    # backup the whole old chart survived the Replace: the new `.ti2` landed
+    # next to the old `.cht`, and `run.chart_cht` — which resolves — then handed
+    # the scanner the OLD chart's recognition file for the NEW chart. A silent
+    # wrong result, and "two charts under one name", which this change is
+    # supposed to make impossible. `chart_tiffs`, `measurement_ti3` and
+    # `profile_icc` already resolved; these did not, which is what made the two
+    # halves disagree (review round 2, defect 2).
+    paths = [run.artefact(".ti1"), run.artefact(".ti2")]
+    paths += [run.artefact(ext) for ext in _CHART_EXTS]
     paths += run.chart_tiffs()
-    paths += [run.measurement_ti3, run.profile_icc, run.dir / f"{s}.icm"]
+    paths += [run.measurement_ti3, run.profile_icc, run.artefact(".icm")]
     # Every sub-folder except old/ itself — the chart they belonged to is going.
     paths += [d for d in run.dir.iterdir() if d.is_dir() and d.name != "old"] \
         if run.dir.exists() else []


### PR DESCRIPTION
Closes register item **B8-61**, handed to the Windows VM because only a Windows machine can prove either the fault or the fix.

## The fault

macOS (APFS/HFS+) is normalisation-**insensitive**: a path spelled NFC (`ü` as one code point) finds a file written NFD (`u` + combining diaeresis). **NTFS is normalisation-sensitive.** So a project restored from a Mac has NFD file names, ChromIQ asks for NFC, and `Path.exists()` answers `False` while the file sits in the folder.

Reproduced on NTFS before a line was changed:

```
on disk (NFD): 'Müller-Prüfdruck.ti2'   asked (NFC): 'Müller-Prüfdruck.ti2'
run.chart_ti2.exists()  -> False        <- the fault
files_matching('*.ti2') -> finds it
run.chart_tiffs()       -> 4 pages      <- finds them
:2238 would pick        -> …ti1  (SILENT SUBSTITUTION)
```

`ui/main_window.py:2238` doesn't refuse — it quietly uses a **different chart**. A wrong result, not a crash.

## Proved on screen, in the real app

Offscreen tests cannot see this: the fault lives in the live UI path. Driven in the real app, German, sandboxed settings, real ArgyllCMS fixtures:

| | before | after |
|---|---|---|
| `:2238` resolves | `.ti1`, **180 patches** | `.ti2`, **462 patches** |
| patch cube, under *"Aktuelles Chart"* | "180 Messfelder" | "462 Messfelder" |
| Create Chart tab | *"Für diesen Profillauf gibt es noch kein Chart"* | the chart, "Messfelder gesamt 462" |

**And the on-screen run found something no unit test could:** the Print tab renders the sheet — *"Seite 1 / 3"*, **"DIESE SEITE DRUCKEN"** live — in **both** states, because `chart_tiffs()` always matched spelling-insensitively. So before this fix **one window simultaneously printed the chart and said it did not exist.** Verified twice, by two independent drivers with different fixtures (390/240 and 180/462 patches).

## Where the fix belongs — argued, not assumed

The handover proposed routing through `files_matching`. That is the wrong tool: it returns a *list*, and `<stem>.ti2` is one file named exactly. The fix is a single-path `resolve_existing()` **at the accessor**, because:

1. **The path must OPEN.** `load_rgb_program()`, `shutil.copy2(…, run.chart_ti2)` and `note_generated_chart` all *use* it. A call-site `.exists()` fix answers "yes" and hands back a name `open()` refuses — the failure moves rather than goes.
2. **~155 call sites, and the next one isn't written yet.**
3. **The write path needs it too**, or a composed write lays a second identical-looking `.ti2` beside the restored one.

**The exact spelling always wins** (an `exists()` fast path), so a file is never swapped for a neighbour. Case now folds through the same `_NAME_CASEFOLD` flag `files_matching` uses eighty lines earlier, so the two cannot drift.

## The interesting part: making the guard truthful ran code that had never run

An independent hostile review upheld the mechanism and then found **two new defects the fix itself activated** — guards that were permanently `False` on NTFS became `True`, running paths that had **never executed on Windows**, and those paths still built names with raw f-strings:

* **`adopt_run_chart_as_verify`** — the chart moved into `verifications/` and its only page was **orphaned in the run root**, leaving the exact "tiffs but no `.ti2`" contradiction this commit removes elsewhere. Six lines under a comment saying that missing it reproduces Knut #130 *"Verification shows no preview"*. Its own test created no `.tif`, so it could not see the file.
* **`archive_run_for_replace`** — the old NFD chain was not archived, so `run.chart_cht` handed the scanner **the OLD chart's recognition file for the NEW `.ti2`**. "Two charts under one name" — the thing this change exists to prevent.

Rather than patch those two, the same shape was swept for and fixed in **six more places**, including a profiling-chart snapshot that had been **silently saving nothing** — a safety net this change is what made matter.

## Deliberately not fixed, documented in code

**Case A** — a fully decomposed tree asked for by a composed name. Fixing it means changing either the "folder name is always NFC" invariant or `working_dir`'s re-clean-and-compare: a differently-**cased** name survives that round trip (`_sanitise` preserves case), a differently-**accented** one cannot. That is a decision to review, not something to slip into a bug fix. Today's behaviour is pinned by a test so it is a measured fact.

**`SameFileError`** — could not reproduce; both plausible sites copy into a freshly created or temp directory, so the destination cannot resolve onto the source. No speculative `try/except` added across sixteen call sites on a maybe.

## Evidence

* **Six mutants, each landing on the test written for it** (M1/M2/M3/M4/M6 fail exactly one; M5, which drops `sorted`, fails 19 — pinned by feeding `os.scandir` back reversed).
* **Zero regressions.** Affected files, offscreen, serial, no `PYTHONUTF8`: **13 failing on master, the same 13 on this branch**, while passing goes 57 → 91. Whole-suite delta across 201 files: `28 failed / 2658 passed` → `28 failed / 2692 passed`, **no new failures**.
* One new failure did appear mid-round and was ours: a test asserting on the *source* of `reset_chart_artefacts`. The rule it protects still holds; it now looks for the extension **and** asserts the wipe goes through `self.artefact(ext)` — stronger than before.
* Writing the guard's test caught a wrong example of our own: accented Greek `ή` (U+03AE) genuinely does decompose, so both halves are now tested.

## Mirror case

A name typed on Windows (NFC) read on macOS needs nothing: Windows produces composed names and APFS is insensitive *and* preserving. The shape that does bite — a decomposed folder holding composed files — is covered by `test_the_mirror_shape_resolves_too`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXFQwMgD9Uc6ZfySU2gXKB