### PR TITLE
The Windows gate's 13 errors were two POSIX assumptions, and one of them was leaking 8 processes a run

### DIFF
--- a/scripts/scanner_sweep/scanner_window_sweep.py
+++ b/scripts/scanner_sweep/scanner_window_sweep.py
@@ -16,13 +16,27 @@ from pathlib import Path
 
 ROOT = Path(os.environ.get("CHROMIQ_TREE", "/Users/Basti/develop/ChromIQ"))
 sys.path.insert(0, str(ROOT))
-WORK = Path("/private/tmp/agentJ")
-OUT = WORK / "out"; OUT.mkdir(parents=True, exist_ok=True)
-SHOTS = Path("/Users/Basti/Desktop/beta 8/11-regression-sweep/shots")
-SHOTS.mkdir(parents=True, exist_ok=True)
+#: NOTHING HERE IS CREATED AT IMPORT TIME, and every root is overridable.
+#: These are macOS absolute paths; on Windows a leading slash is *drive*-
+#: relative, so merely importing this module used to try `mkdir C:\Users\Basti`
+#: (`PermissionError: [WinError 5]`) and take the five tests in
+#: `tests/test_the_sweep_is_runnable.py` down as ERRORs at fixture setup —
+#: while quietly leaving `C:\private\tmp\agentJ\out` behind on the way. Those
+#: tests import this module only to inspect `CHECKS`; a module that cannot be
+#: imported without write access to somebody's Desktop cannot be tested.
+#: The directories are made by whoever writes into them (`_ensure_dirs`).
+#: `.get(NAME) or default`, never `.get(NAME, default)`: a variable that is
+#: SET BUT EMPTY returns "", and `Path("")` is `.` — so `AGENTJ_WORK=`
+#: would make OUT the relative path `out`, and run-sweep.sh has already
+#: `cd`-ed into the repo by then. The sweep would write its results into
+#: the checkout it is testing, which is the one thing the header above
+#: promises it never does.
+WORK = Path(os.environ.get("AGENTJ_WORK") or "/private/tmp/agentJ")
+OUT = WORK / "out"
+_DESK = Path(os.environ.get("AGENTJ_DESK") or "/Users/Basti/Desktop/beta 8")
+SHOTS = _DESK / "11-regression-sweep" / "shots"
 _TAG = os.environ.get("AGENTJ_TAG", "base")
-_PROGRESS_DIR = Path("/Users/Basti/Desktop/beta 8/_progress")
-_PROGRESS_DIR.mkdir(parents=True, exist_ok=True)
+_PROGRESS_DIR = _DESK / "_progress"
 #: ONE FILE PER RUN, never a fixed name. This used to be a constant
 #: `agentJ.md`, so the second sweep silently overwrote the first one's log —
 #: the evidence for one finding replaced by the evidence for a later run on a
@@ -59,7 +73,47 @@ if RESULTS.is_file():
 BOXES: list[tuple[str, str]] = []      # (kind, text) of every QMessageBox shown
 
 
+def _ensure_dirs():
+    """Create the output roots. Called by `main()` before the first check, and
+    again by `out_file` / `shot_path` / `record` at each write, never at import
+    — see WORK above."""
+    for d in (OUT, SHOTS, _PROGRESS_DIR):
+        d.mkdir(parents=True, exist_ok=True)
+
+
+def out_file(name):
+    """The one door to OUT. Writers say `out_file("J02-targets.json")`, not
+    `OUT / "J02-targets.json"`, so that no writer silently depends on `main()`
+    having run `_ensure_dirs()` first — which is exactly the coupling this
+    module was changed to drop."""
+    OUT.mkdir(parents=True, exist_ok=True)
+    return OUT / name
+
+
+def shot_path(name):
+    """The one door to SHOTS. See `out_file`."""
+    SHOTS.mkdir(parents=True, exist_ok=True)
+    return SHOTS / name
+
+
+def save_shot(paintable, name):
+    """Save a QImage/QPixmap into SHOTS and return its path, RAISING if Qt
+    could not write it.
+
+    `QImage.save()` into a directory that does not exist returns False and
+    raises nothing. A screenshot would then never be written while `record()`
+    filed its path as `evidence=` regardless — a sweep citing a picture that
+    does not exist. A check that raises here is recorded as FAIL by `main()`,
+    which is the honest outcome."""
+    p = shot_path(name)
+    if not paintable.save(str(p)):
+        raise OSError("Qt could not write the screenshot %s" % p)
+    return str(p)
+
+
 def record(cid, name, status, note, evidence=""):
+    RESULTS.parent.mkdir(parents=True, exist_ok=True)
+    PROGRESS.parent.mkdir(parents=True, exist_ok=True)
     row = {"id": cid, "name": name, "status": status, "note": note,
            "evidence": evidence, "when": time.strftime("%H:%M:%S")}
     _results[:] = [r for r in _results if r["id"] != cid] + [row]
@@ -90,9 +144,7 @@ def click(btn):
 
 
 def shot(w, name):
-    p = SHOTS / name
-    w.grab().save(str(p))
-    return str(p)
+    return save_shot(w.grab(), name)
 
 
 # ---- QMessageBox: never block. Record every one, answer the default. -------
@@ -259,7 +311,7 @@ def j02(c):
         rows.append((label, key, nrects, npages))
         if nrects == 0:
             bad.append(f"{label} ({key}): grid has no cells")
-    (OUT / "J02-targets.json").write_text(json.dumps(rows, indent=1, default=str), encoding="utf-8")
+    out_file("J02-targets.json").write_text(json.dumps(rows, indent=1, default=str), encoding="utf-8")
     record("J02", "Target combo — every entry builds a grid",
            "FAIL" if bad else "PASS",
            f"{len(rows)} entries; multi-page sets: "
@@ -1182,7 +1234,7 @@ def j28(c):
                      verdict[:220]))
         if not (on_patches and good):
             bad.append(key)
-    (OUT / "J28-targets.json").write_text(json.dumps(rows, indent=1), encoding="utf-8")
+    out_file("J28-targets.json").write_text(json.dumps(rows, indent=1), encoding="utf-8")
     record("J28", "Demo -> Auto align -> Check alignment",
            "FAIL" if bad else "PASS",
            "; ".join(f"{r[0]}: {r[1]} [{r[2]}] {r[3]}" for r in rows))
@@ -1256,7 +1308,7 @@ def j29(c):
                     cache = cache_state(d._marquee)
                     if cache == "STALE":
                         bad.append(tag + " STALE CACHE")
-    (OUT / "J29-cross.json").write_text(json.dumps(rows, indent=1), encoding="utf-8")
+    out_file("J29-cross.json").write_text(json.dumps(rows, indent=1), encoding="utf-8")
     record("J29", "Crossed: fiducials x sample area x page",
            "FAIL" if bad else "PASS",
            f"{len(rows)} combinations driven end to end (Auto align + Check "
@@ -1427,7 +1479,7 @@ def j33(c):
                 if img.pixelColor(x, y).alpha() > 200}
         rows.append((mode, fill, mark, f"{opaque}/{total} opaque",
                      f"{len(cols)} distinct colours"))
-        img.save(str(SHOTS / f"J33-warning-sign-{mode}.png"))
+        save_shot(img, f"J33-warning-sign-{mode}.png")
         if opaque < 0.25 * total:
             bad.append(f"{mode}: the sign is nearly transparent")
         if len(cols) < 2:
@@ -1472,7 +1524,7 @@ def j34(c):
         pump(700)
         name = f"J34-warning-{tag[0]}.png"
         tag[0] += 1
-        self.grab().save(str(SHOTS / name))
+        save_shot(self.grab(), name)
         icon_ok = not self.iconPixmap().isNull()
         btns = [b.text() for b in self.buttons()]
         dflt = self.defaultButton().text() if self.defaultButton() else ""
@@ -1556,6 +1608,7 @@ def j35(c):
 
 # ==========================================================================
 def main():
+    _ensure_dirs()
     want = sys.argv[1:]
     c = Ctx()
     ids = want or sorted(CHECKS)

--- a/tests/test_cr30_external_values.py
+++ b/tests/test_cr30_external_values.py
@@ -185,8 +185,25 @@ class Reader:
         # close. An earlier attempt at this fix closed first and did nothing.
         if self.p.poll() is None:
             try:
-                os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
+                # One `hasattr` for all three POSIX-only names — `os.killpg`,
+                # `os.getpgid` and `signal.SIGKILL` arrive together or not at
+                # all, and on Windows it is not at all. The AttributeError used
+                # to escape this fixture as an ERROR at teardown on eight
+                # otherwise-passing tests, AND it raised before anything was
+                # killed: master leaks one orphan chromiq-chartread.exe per
+                # test. `start_new_session=True` above is silently ignored on
+                # Windows (CPython names the parameter `unused_start_new_
+                # session`), so there is no group there to signal anyway —
+                # terminate the helper itself. It spawns nothing.
+                if hasattr(os, "killpg"):
+                    os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
+                else:
+                    self.p.kill()
+            # OSError joins the tuple for `Popen.kill()` on Windows, which can
+            # raise it when the process is between poll() and here. It subsumes
+            # the other two members; they stay because they are what the POSIX
+            # branch means to tolerate, and deleting them would hide that.
+            except (ProcessLookupError, PermissionError, OSError):
                 pass
         try:
             self.p.wait(timeout=5)


### PR DESCRIPTION
The Windows gate now completes (`123 failed, 10967 passed, **13 errors**, 17:57, zero worker deaths`). This closes the 13. They were **errors, not failures** — setup and teardown, not assertions — and they turned out to be two unrelated POSIX assumptions.

## 1. A module that could not be imported without write access to one person's Desktop

`scripts/scanner_sweep/scanner_window_sweep.py` created its output directories **at import time** from hard-coded macOS paths. On Windows a leading `/` is drive-relative, so `parents=True` walked to `C:\Users\Basti`:

```
ERROR at setup of test_every_check_is_registered_and_callable
scripts\scanner_sweep\scanner_window_sweep.py:22: in <module>
    SHOTS.mkdir(parents=True, exist_ok=True)
E   PermissionError: [WinError 5] Zugriff verweigert: '\Users\Basti'
```

That errored all 5 tests in `test_the_sweep_is_runnable.py` at fixture setup. The file's own skip guard checks the repo tree, so it could never catch this.

**And the line before it succeeded** — so every gate run on Windows was silently creating an empty `C:\private\tmp\agentJ\out` at the drive root. Confirmed by observation: it reappears on master, not on this branch.

Fixed **in the script, not the test**, because the test is right: a module you cannot import without a particular Desktop is the defect. Nothing is `mkdir`ed at import; `_ensure_dirs()` runs as `main()`'s first statement, and `AGENTJ_WORK` / `AGENTJ_DESK` default to the old paths — `run-sweep.sh` sets neither, so **macOS resolves byte-identically** (verified with `PurePosixPath`).

## 2. `os.killpg` does not exist on Windows — and it was leaking helpers

All 8 CR30 errors were **at teardown; every test body passed.**

```
ERROR at teardown of test_a_wrong_value_is_flagged_not_silently_accepted
>   os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
E   AttributeError: module 'os' has no attribute 'killpg'
```

`killpg`, `getpgid` and `SIGKILL` are all absent on Windows and `AttributeError` was not in the `except` tuple, so it escaped the fixture. `start_new_session=True` is silently ignored — CPython 3.12.10's Windows `_execute_child` literally names the parameter `unused_start_new_session` (`subprocess.py:1447`) — so there was never a process group to signal.

**The consequence is worse than a red gate.** Because `killpg` raised *before* killing anything, **master leaks 8 orphaned `chromiq-chartread.exe` per run of this file.** This branch leaks zero. Confirmed across ~6 runs, three times — and **81 such orphans were resident on the test machine**, the oldest dating from 2026-08-30. They have now been reaped.

The helper is safe to `kill()` directly: no `fork`/`exec`/`system`/`popen`/`CreateProcess` in its `.c` sources, and at runtime `direct children: []`, `kill()` returning in 0.00 s with nothing orphaned.

## Result

| file | master | this branch |
|---|---|---|
| `test_the_sweep_is_runnable.py` | 1 passed, **5 errors** | **6 passed** |
| `test_cr30_external_values.py` | 12 passed, **8 errors** | **12 passed** |

**18 passed, 0 errors.** Nothing skipped, xfailed, or weakened — the only deletions are two lines inside `Reader.kill()`. Four of #159's `-x`/`--json` blockers are now genuinely guarded on Windows instead of lost in the noise.

## Reviewed, and three defects fixed before this was opened

A hostile review reproduced every claim, reverted each half independently to prove both are load-bearing, and found three things:

* **Five writers bypassed the lazy `mkdir`** — and `QImage.save` into a missing directory returns **`False` with no exception**, while `write_text` raises. A sweep could file an `evidence=` link to a screenshot that was never written. Now one door per root (`out_file()`, `shot_path()`) plus `save_shot()`, which checks Qt's return value and raises when a write is refused. Verified with both roots pointed at a non-existent directory; `bypassing writers left: []`.
* **`os.environ.get(NAME, default)` returns `""` for a set-but-empty variable**, which would have made the output root relative and written into the checkout. Now `... or "<default>"`.
* **The commit message claimed macOS was untouched, which was false** — the shared `except` gained `OSError`. The message now says what actually changed and why.

One related shape was deliberately **not** changed and is flagged instead: `scanner_window_sweep.py:17` `ROOT = Path(os.environ.get("CHROMIQ_TREE", …))` has the same set-but-empty hazard. It is master's line and `run-sweep.sh` always sets it non-empty.

## Not verified here

No macOS execution — the byte-identical claim is proved by path resolution, not by running it there. The sweep still cannot *run* on Windows (zsh runner, on-screen dialog); this makes it **importable and testable** there, nothing more. No full `--runslow` re-run; the claim is scoped to these two files run serially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXFQwMgD9Uc6ZfySU2gXKB