### PR TITLE
A driverless instrument reported as driven, because a ghost from an old USB port still had the driver

### DIFF
--- a/core/usb_driver_installer.py
+++ b/core/usb_driver_installer.py
@@ -131,26 +131,157 @@ def _wdi_simple_path() -> Path:
     return resource_path("assets/wdi_simple.exe")
 
 
-def enumerate_connected() -> list[UsbDevice]:
-    """Return connected USB devices that match the known colorimeter list."""
-    if sys.platform != "win32":
-        return []
-    import winreg
-    found: list[UsbDevice] = []
-    try:
-        base = winreg.OpenKey(
-            winreg.HKEY_LOCAL_MACHINE, r"SYSTEM\CurrentControlSet\Enum\USB"
-        )
-    except OSError:
-        return []
+# ---------------------------------------------------------------------------
+# Which of the remembered devices is actually attached
+# ---------------------------------------------------------------------------
+#
+# `HKLM\SYSTEM\CurrentControlSet\Enum\USB` is a MEMORY, NOT A CENSUS. Windows
+# keeps a subkey for every USB device the machine has ever seen, for ever, and
+# for every port each one was ever plugged into. A plain walk of it therefore
+# answers "what has this machine known?", which is not the question anyone here
+# is asking.
+#
+# Measured on the ARM64 box, 2026-09-05: the registry remembered 6 vid:pid,
+# cfgmgr32 said 5 were present; and the ONE attached instrument had two instance
+# keys, only one of which was live. Both halves of that matter, and they fail
+# differently:
+#
+#   • a remembered vid:pid that is gone  -> a device reported as connected when
+#     it is not in the building. `unbound_targets()` then says "the driver did
+#     not bind" about hardware that cannot bind anything.
+#   • a remembered INSTANCE that is gone -> its stale `Service` value is OR-ed
+#     into `has_winusb`. Move the instrument to another USB port and the old
+#     ghost's `libusb0` masks the new instance's missing driver, so
+#     `unbound_targets()` returns empty and the app claims an install that never
+#     happened. That is precisely the failure `unbound_targets()` exists to
+#     catch, so the check must not be built on the thing it is checking.
+#
+# `CM_Get_Device_ID_ListW` with `CM_GETIDLIST_FILTER_PRESENT` answers the real
+# question, at instance granularity, with no extra dependency.
+#
+# ONE IMPLEMENTATION, DELIBERATELY. This used to live in
+# `ui/dialogs/settings_dialog.py`, where it filtered the dialog's own call and
+# left `unbound_targets()` — the other caller, and the one whose entire job is
+# to not be fooled — reading ghosts. A filter that lives beside one caller is a
+# filter the next caller will not know about. It belongs where the ghosts come
+# from, so that no consumer of `enumerate_connected()` has to remember anything.
+#
+# NOTE ON THE FAILURE DIRECTION. When the question cannot be asked at all — not
+# Windows, no cfgmgr32, the call fails — `present_usb_instance_ids()` returns
+# None and NOTHING is filtered. A ghost in the list is a lie the user can see
+# and ignore. A real instrument filtered OUT is a working feature that silently
+# refuses to help. Of the two, only the first is survivable, so the fallback is
+# deliberately the noisy one.
 
-    i = 0
-    while True:
-        try:
-            combo = winreg.EnumKey(base, i)   # e.g. "VID_0765&PID_5020"
-        except OSError:
-            break
-        i += 1
+#: `CM_GETIDLIST_FILTER_ENUMERATOR` — restrict to the "USB" enumerator.
+_CM_GETIDLIST_FILTER_ENUMERATOR = 0x00000001
+#: `CM_GETIDLIST_FILTER_PRESENT` — the whole point: attached right now.
+_CM_GETIDLIST_FILTER_PRESENT = 0x00000100
+_CR_SUCCESS = 0
+
+
+def usb_ids_in_instance(instance_id: str) -> "tuple[str, str] | None":
+    r"""The (vid, pid) inside a PnP instance ID, lower-case, or None.
+
+    ``USB\VID_1A86&PID_7523\7&3b74c78&0&1`` → ``("1a86", "7523")``.
+    Composite children carry a third token (``&MI_00``) and hubs carry no VID
+    at all (``USB\ROOT_HUB30\…``); both are handled by looking for the tokens
+    rather than counting them.
+
+    Lower-case out, because the registry side of the comparison is lower-cased
+    too and the two have to agree — Windows writes these IDs upper-case.
+    """
+    parts = instance_id.split("\\")
+    if len(parts) < 2:
+        return None
+    vid = pid = None
+    for token in parts[1].upper().split("&"):
+        if token.startswith("VID_"):
+            vid = token[4:].lower()
+        elif token.startswith("PID_"):
+            pid = token[4:].lower()
+    if vid is None or pid is None:
+        return None
+    return vid, pid
+
+
+def present_usb_instance_ids() -> "set[str] | None":
+    """Every USB device-instance ID attached right now, UPPER-CASE.
+
+    None means the question could not be asked — see the note above: callers
+    must then filter nothing rather than hide anything. An empty set is a real
+    answer ("nothing is attached") and is NOT the same as None.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        cfgmgr = ctypes.WinDLL("cfgmgr32")
+        flags = ctypes.c_ulong(
+            _CM_GETIDLIST_FILTER_ENUMERATOR | _CM_GETIDLIST_FILTER_PRESENT)
+        enumerator = ctypes.c_wchar_p("USB")
+        size = ctypes.c_ulong(0)
+        if cfgmgr.CM_Get_Device_ID_List_SizeW(
+                ctypes.byref(size), enumerator, flags) != _CR_SUCCESS:
+            return None
+        buf = ctypes.create_unicode_buffer(size.value)
+        if cfgmgr.CM_Get_Device_ID_ListW(
+                enumerator, buf, size, flags) != _CR_SUCCESS:
+            return None
+        raw = buf[:size.value]
+    except Exception as exc:   # noqa: BLE001 — a missing DLL must not kill the caller
+        log.warning("could not ask Windows which USB devices are present: %s", exc)
+        return None
+    return {one.upper() for one in raw.split("\0") if one}
+
+
+def present_usb_ids() -> "set[tuple[str, str]] | None":
+    """Every (vid, pid) attached to this machine right now, or None.
+
+    Derived from `present_usb_instance_ids()`, so this module asks cfgmgr32
+    exactly once and cannot hold two answers that disagree.
+    """
+    instances = present_usb_instance_ids()
+    if instances is None:
+        return None
+    return {ids for one in instances
+            if (ids := usb_ids_in_instance(one)) is not None}
+
+
+def _instance_id(combo: str, instance: str) -> str:
+    r"""Rebuild the PnP instance ID a registry path stands for, UPPER-CASE.
+
+    ``VID_0765&PID_6008`` + ``7&3b74c78&0&1``
+    → ``USB\VID_0765&PID_6008\7&3B74C78&0&1``.
+
+    The registry's key names reproduce the middle token of the instance ID
+    exactly, composite ``&MI_00`` children included, so this compares character
+    for character against cfgmgr32's list once both are upper-cased.
+    """
+    return ("USB\\" + combo + "\\" + instance).upper()
+
+
+def attached_devices(
+    entries: "list[tuple[str, list[tuple[str, str]]]]",
+    present_instances: "set[str] | None",
+) -> list[UsbDevice]:
+    """The known colorimeters among *entries* that are attached right now.
+
+    *entries* is what the registry holds, already read out:
+    ``[(combo_key, [(instance_key, service), …]), …]`` — e.g.
+    ``("VID_0765&PID_6008", [("7&3b74c78&0&1", "libusb0")])``. A service that
+    could not be read is ``""``.
+
+    *present_instances* is `present_usb_instance_ids()`: upper-case instance
+    IDs, or None for "could not ask", in which case nothing is filtered.
+
+    Pure — no registry, no ctypes — so it runs and is tested on every OS.
+    """
+    present_pairs = (None if present_instances is None
+                     else {ids for one in present_instances
+                           if (ids := usb_ids_in_instance(one)) is not None})
+
+    found: list[UsbDevice] = []
+    for combo, instances in entries:
         parts = combo.upper().split("&")
         if len(parts) < 2:
             continue
@@ -160,27 +291,31 @@ def enumerate_connected() -> list[UsbDevice]:
         if name is None:
             continue
 
-        # Check if any instance already has WinUSB as its service driver.
-        has_winusb = False
-        try:
-            dev_key = winreg.OpenKey(base, combo)
-            j = 0
-            while True:
-                try:
-                    inst = winreg.EnumKey(dev_key, j)
-                    inst_key = winreg.OpenKey(dev_key, inst)
-                    try:
-                        svc, _ = winreg.QueryValueEx(inst_key, "Service")
-                        if str(svc).lower() in ("winusb", "libusb0"):
-                            has_winusb = True
-                    except OSError:
-                        pass
-                    j += 1
-                except OSError:
-                    break
-        except OSError:
-            pass
+        # GUARD 1 — remembered, but gone. Drop it here: nothing downstream
+        # should ever be handed a device that is not attached.
+        if present_pairs is not None and (vid, pid) not in present_pairs:
+            log.debug("skipping %s:%s (%s): remembered by the registry, "
+                      "not attached", vid, pid, name)
+            continue
 
+        # GUARD 2 — remembered INSTANCES of a device that IS attached. Only the
+        # live ones may speak for the driver state; a ghost instance's stale
+        # `Service` is exactly what fools the post-install check.
+        live = instances
+        if present_instances is not None:
+            live = [pair for pair in instances
+                    if _instance_id(combo, pair[0]) in present_instances]
+            if not live:
+                # cfgmgr32 says this vid:pid IS here but no instance ID matched.
+                # Presence is not in doubt, only which node it is, so fall back
+                # rather than hide a real instrument — see the note on the
+                # failure direction above.
+                log.debug("no instance of %s:%s matched the present list; "
+                          "falling back to every remembered instance", vid, pid)
+                live = instances
+
+        has_winusb = any(
+            str(service).lower() in ("winusb", "libusb0") for _, service in live)
         found.append(UsbDevice(vid=vid, pid=pid, name=name, has_winusb=has_winusb))
 
     # Composite USB devices register multiple keys per VID/PID (parent + MI_xx
@@ -193,6 +328,64 @@ def enumerate_connected() -> list[UsbDevice]:
             seen.add(key)
             unique.append(dev)
     return unique
+
+
+def _registry_usb_entries() -> "list[tuple[str, list[tuple[str, str]]]]":
+    r"""Read ``Enum\USB`` into the plain data `attached_devices()` consumes.
+
+    Everything this returns is REMEMBERED, not present. The filtering is
+    `attached_devices()`'s job and happens in exactly one place.
+    """
+    import winreg
+    try:
+        base = winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, r"SYSTEM\CurrentControlSet\Enum\USB"
+        )
+    except OSError:
+        return []
+
+    entries: "list[tuple[str, list[tuple[str, str]]]]" = []
+    i = 0
+    while True:
+        try:
+            combo = winreg.EnumKey(base, i)   # e.g. "VID_0765&PID_5020"
+        except OSError:
+            break
+        i += 1
+
+        instances: "list[tuple[str, str]]" = []
+        try:
+            dev_key = winreg.OpenKey(base, combo)
+            j = 0
+            while True:
+                try:
+                    inst = winreg.EnumKey(dev_key, j)
+                except OSError:
+                    break
+                j += 1
+                try:
+                    svc, _ = winreg.QueryValueEx(
+                        winreg.OpenKey(dev_key, inst), "Service")
+                except OSError:
+                    svc = ""
+                instances.append((inst, str(svc)))
+        except OSError:
+            pass
+        entries.append((combo, instances))
+    return entries
+
+
+def enumerate_connected() -> list[UsbDevice]:
+    """Return the known colorimeters ATTACHED RIGHT NOW, with their driver state.
+
+    "Connected" is meant literally: devices the registry merely remembers are
+    filtered out here, once, so that no caller has to know the registry
+    remembers anything. See the long note above for why, and for what happens
+    when Windows cannot be asked.
+    """
+    if sys.platform != "win32":
+        return []
+    return attached_devices(_registry_usb_entries(), present_usb_instance_ids())
 
 
 def install_winusb(device: UsbDevice) -> bool:

--- a/tests/test_usb_driver_dialog.py
+++ b/tests/test_usb_driver_dialog.py
@@ -306,108 +306,23 @@ def test_the_text_functions_need_no_qt_and_no_windows(monkeypatch):
 # HKLM\SYSTEM\CurrentControlSet\Enum\USB, which remembers every USB device the
 # machine has ever seen. The window then said "Connected colorimeter: X-Rite i1
 # Studio" about hardware that was not in the building.
-
-PRESENT_LIST = [
-    r"USB\ROOT_HUB30\5&32007b01&0&0",
-    r"USB\VID_0765&PID_6008\7&2a0c73b9&0&0002",
-    r"USB\VID_1A86&PID_7523\7&3b74c78&0&1",
-    r"USB\VID_0E0F&PID_000B&MI_00\7&2a0c73b9&0&0000",
-]
-
-
-@pytest.mark.parametrize("instance_id, expected", [
-    (r"USB\VID_1A86&PID_7523\7&3b74c78&0&1", ("1a86", "7523")),
-    (r"USB\VID_0765&PID_6008\7&2a0c73b9&0&0002", ("0765", "6008")),
-    # a composite child carries a third token and must still resolve
-    (r"USB\VID_0E0F&PID_000B&MI_00\7&2a0c73b9&0&0000", ("0e0f", "000b")),
-    # hubs have no VID at all
-    (r"USB\ROOT_HUB30\5&32007b01&0&0", None),
-    (r"USB\ROOT_HUB20\4&2ec99baf&0", None),
-    # malformed input must not raise
-    ("", None),
-    ("USB", None),
-    (r"USB\NOT_A_DEVICE", None),
-    (r"USB\VID_1A86\7&3b74c78&0&1", None),      # VID without PID
-])
-def test_the_ids_are_read_out_of_a_pnp_instance_id(instance_id, expected):
-    assert sd.usb_ids_in_instance(instance_id) == expected
-
-
-def test_the_ids_come_back_lower_case_whatever_case_windows_used():
-    """`enumerate_connected` lower-cases what it reads, so the two sides of the
-    comparison have to agree — Windows writes these IDs upper-case."""
-    assert sd.usb_ids_in_instance(
-        r"usb\vid_1a86&pid_7523\7&3b74c78&0&1") == ("1a86", "7523")
-
-
-def _ghost():
-    """A device Windows remembers and no longer has."""
-    return SimpleNamespace(vid="0765", pid="6008", name="X-Rite i1 Studio",
-                           has_winusb=True)
-
-
-def _real():
-    return SimpleNamespace(vid="0971", pid="2000", name=I1PRO, has_winusb=False)
-
-
-def test_a_remembered_device_that_is_not_attached_is_dropped():
-    present = {("0971", "2000")}
-    assert sd.attached_only([_ghost(), _real()], present) == [_real()]
-
-
-def test_an_attached_device_survives_the_filter():
-    present = {("0765", "6008")}
-    kept = sd.attached_only([_ghost()], present)
-    assert [d.name for d in kept] == ["X-Rite i1 Studio"]
-
-
-def test_the_filter_is_case_insensitive_on_both_sides():
-    dev_upper = SimpleNamespace(vid="0765", pid="6008", name="x", has_winusb=True)
-    assert sd.attached_only([dev_upper], {("0765", "6008")}) == [dev_upper]
-
-
-def test_nothing_present_means_nothing_reported():
-    assert sd.attached_only([_ghost(), _real()], set()) == []
-
-
-def test_when_windows_cannot_be_asked_everything_is_shown():
-    """The failure direction is chosen deliberately: a ghost is a lie the user
-    can see and ignore, a filtered-out real instrument is a feature that
-    silently refuses to help. Only the first is survivable."""
-    devices = [_ghost(), _real()]
-    assert sd.attached_only(devices, None) == devices
-
-
-def test_the_filter_returns_a_new_list_and_does_not_mutate_the_input():
-    devices = [_ghost(), _real()]
-    out = sd.attached_only(devices, None)
-    assert out is not devices
-    assert len(devices) == 2
-
-
-def test_present_usb_ids_says_it_cannot_ask_off_windows(monkeypatch):
-    monkeypatch.setattr(sd, "_sys", SimpleNamespace(platform="linux"))
-    assert sd.present_usb_ids() is None
-
-
-def test_present_usb_ids_survives_a_missing_cfgmgr32(monkeypatch):
-    """A ctypes failure must not take the Preferences window down with it."""
-    import ctypes
-
-    def boom(*_a, **_kw):
-        raise OSError("cfgmgr32 is not here")
-
-    monkeypatch.setattr(sd, "_sys", SimpleNamespace(platform="win32"))
-    monkeypatch.setattr(ctypes, "WinDLL", boom, raising=False)
-    assert sd.present_usb_ids() is None
-
+#
+# THE FILTER USED TO LIVE IN `settings_dialog`, next to this one caller, and so
+# `core.usb_driver_installer.unbound_targets()` — the post-install verification,
+# the one function whose job is to not be fooled — went on reading ghosts. It
+# now lives inside `enumerate_connected()` itself, and the unit tests for it
+# live beside it in `tests/test_usb_driver_installer.py`.
+#
+# What stays here is the only part that is about this window: that a ghost
+# reaches the user as "No colorimeter detected", in the words they read.
 
 def test_the_whole_chain_turns_a_ghost_into_no_colorimeter_detected():
     """The bug, end to end, in the words the user reads."""
-    remembered = [_ghost()]
-    present = {("1a86", "7523")}       # only the serial bridge is attached
+    import core.usb_driver_installer as udi
+    remembered = [("VID_0765&PID_6008", [("7&3b74c78&0&1", "libusb0")])]
+    present = {r"USB\VID_1A86&PID_7523\7&3B74C78&0&1"}   # only the bridge
     msg, btn = sd.usb_installer_text(
-        sd.attached_only(remembered, present), wdi_available=True)
+        udi.attached_devices(remembered, present), wdi_available=True)
     assert msg.startswith("<b>No colorimeter detected.</b>")
     assert "i1 Studio" not in msg
     assert btn is None
@@ -1680,7 +1595,6 @@ def _fixed_hardware(monkeypatch, devices, wdi: bool):
     monkeypatch.setattr(inst, "enumerate_connected", lambda: list(devices))
     monkeypatch.setattr(inst, "unbound_targets", lambda t: [])
     monkeypatch.setattr(inst, "install_winusb", lambda d: True)
-    monkeypatch.setattr(sd, "present_usb_ids", lambda: None)
     monkeypatch.setattr(sd.SettingsDialog, "_serial_states", lambda self: [])
 
     class _P:

--- a/tests/test_usb_driver_installer.py
+++ b/tests/test_usb_driver_installer.py
@@ -7,8 +7,12 @@ so the Settings dialog can tell the user what happened.
 """
 from __future__ import annotations
 
+import inspect
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 import core.usb_driver_installer as udi
 
@@ -164,3 +168,270 @@ def test_unbound_targets_only_considers_requested_devices(monkeypatch) -> None:
         lambda: [_dev("0765", "6008", True), _dev("085c", "0a00", False)],
     )
     assert udi.unbound_targets([target]) == []
+
+
+# ---------------------------------------------------------------------------
+# The ghost devices
+# ---------------------------------------------------------------------------
+#
+# `enumerate_connected()` reads HKLM\SYSTEM\CurrentControlSet\Enum\USB, which
+# remembers every USB device this machine has ever seen and every port each was
+# plugged into. Measured on the ARM64 box 2026-09-04 with no colorimeter
+# attached at all, it returned `X-Rite i1 Studio`.
+#
+# The first fix filtered that in the Preferences dialog. `unbound_targets()` —
+# the OTHER caller, and the post-install verification whose entire job is to
+# answer "did the driver actually bind?" — went on reading ghosts. It is now
+# filtered once, here, at instance granularity, and these tests live beside the
+# code that does it rather than beside one of its callers.
+
+I1STUDIO = ("0765", "6008")
+
+
+@pytest.mark.parametrize("instance_id, expected", [
+    (r"USB\VID_1A86&PID_7523\7&3b74c78&0&1", ("1a86", "7523")),
+    (r"USB\VID_0765&PID_6008\7&2a0c73b9&0&0002", ("0765", "6008")),
+    # a composite child carries a third token and must still resolve
+    (r"USB\VID_0E0F&PID_000B&MI_00\7&2a0c73b9&0&0000", ("0e0f", "000b")),
+    # hubs have no VID at all
+    (r"USB\ROOT_HUB30\5&32007b01&0&0", None),
+    (r"USB\ROOT_HUB20\4&2ec99baf&0", None),
+    # malformed input must not raise
+    ("", None),
+    ("USB", None),
+    (r"USB\NOT_A_DEVICE", None),
+    (r"USB\VID_1A86\7&3b74c78&0&1", None),      # VID without PID
+])
+def test_the_ids_are_read_out_of_a_pnp_instance_id(instance_id, expected) -> None:
+    assert udi.usb_ids_in_instance(instance_id) == expected
+
+
+def test_the_ids_come_back_lower_case_whatever_case_windows_used() -> None:
+    """The registry side is lower-cased, so the two sides of the comparison have
+    to agree — Windows writes these IDs upper-case."""
+    assert udi.usb_ids_in_instance(
+        r"usb\vid_1a86&pid_7523\7&3b74c78&0&1") == ("1a86", "7523")
+
+
+def test_present_usb_instance_ids_says_it_cannot_ask_off_windows(monkeypatch) -> None:
+    monkeypatch.setattr(udi, "sys", SimpleNamespace(platform="linux"))
+    assert udi.present_usb_instance_ids() is None
+
+
+def test_present_usb_instance_ids_survives_a_missing_cfgmgr32(monkeypatch) -> None:
+    """A ctypes failure must not take the Preferences window down with it."""
+    def boom(*_a, **_kw):
+        raise OSError("cfgmgr32 is not here")
+
+    monkeypatch.setattr(udi, "sys", SimpleNamespace(platform="win32"))
+    monkeypatch.setattr(udi.ctypes, "WinDLL", boom, raising=False)
+    assert udi.present_usb_instance_ids() is None
+
+
+def test_present_usb_ids_is_derived_from_the_instance_list(monkeypatch) -> None:
+    """One cfgmgr32 call in this project's USB code, not two that can disagree."""
+    monkeypatch.setattr(udi, "present_usb_instance_ids", lambda: {
+        r"USB\VID_0765&PID_6008\7&3B74C78&0&1",
+        r"USB\VID_0E0F&PID_000B&MI_00\7&2A0C73B9&0&0000",
+        r"USB\ROOT_HUB30\5&32007B01&0&0",          # no VID: dropped
+    })
+    assert udi.present_usb_ids() == {("0765", "6008"), ("0e0f", "000b")}
+
+
+def test_present_usb_ids_passes_could_not_ask_straight_through(monkeypatch) -> None:
+    monkeypatch.setattr(udi, "present_usb_instance_ids", lambda: None)
+    assert udi.present_usb_ids() is None
+
+
+# --- GUARD 1: a device the registry remembers and the machine no longer has --
+
+def _entry(vid: str, pid: str, *instances):
+    """One `Enum\\USB` combo key, as `_registry_usb_entries()` hands it over."""
+    return (f"VID_{vid.upper()}&PID_{pid.upper()}", list(instances))
+
+
+def _present(vid: str, pid: str, instance: str) -> str:
+    return (f"USB\\VID_{vid}&PID_{pid}\\{instance}").upper()
+
+
+def test_a_remembered_device_that_is_not_attached_is_dropped() -> None:
+    entries = [
+        _entry("0765", "6008", ("7&3b74c78&0&1", "libusb0")),   # ghost
+        _entry("0971", "2000", ("7&2a0c73b9&0&2", "")),         # attached
+    ]
+    present = {_present("0971", "2000", "7&2a0c73b9&0&2")}
+    assert [(d.vid, d.pid) for d in udi.attached_devices(entries, present)] == [
+        ("0971", "2000")]
+
+
+def test_an_attached_device_survives_the_filter() -> None:
+    entries = [_entry("0765", "6008", ("7&3b74c78&0&1", "libusb0"))]
+    present = {_present("0765", "6008", "7&3b74c78&0&1")}
+    kept = udi.attached_devices(entries, present)
+    assert [d.name for d in kept] == ["X-Rite i1 Studio"]
+
+
+def test_nothing_present_means_nothing_reported() -> None:
+    entries = [_entry("0765", "6008", ("7&3b74c78&0&1", "libusb0"))]
+    assert udi.attached_devices(entries, set()) == []
+
+
+def test_when_windows_cannot_be_asked_everything_is_shown() -> None:
+    """The failure direction is chosen deliberately: a ghost is a lie the user
+    can see and ignore, a filtered-out real instrument is a feature that
+    silently refuses to help. Only the first is survivable."""
+    entries = [
+        _entry("0765", "6008", ("7&3b74c78&0&1", "libusb0")),
+        _entry("0971", "2000", ("7&2a0c73b9&0&2", "")),
+    ]
+    assert [(d.vid, d.pid) for d in udi.attached_devices(entries, None)] == [
+        ("0765", "6008"), ("0971", "2000")]
+
+
+def test_the_comparison_is_case_insensitive_on_both_sides() -> None:
+    """Windows writes instance IDs upper-case; the registry key names come back
+    in whatever case they were created with."""
+    entries = [("vid_0765&pid_6008", [("7&3b74c78&0&1", "WinUSB")])]
+    present = {r"USB\VID_0765&PID_6008\7&3B74C78&0&1"}
+    got = udi.attached_devices(entries, present)
+    assert [(d.vid, d.pid, d.has_winusb) for d in got] == [("0765", "6008", True)]
+
+
+def test_devices_that_are_not_known_colorimeters_are_still_ignored() -> None:
+    """Presence is a second filter, not a replacement for the allowlist."""
+    entries = [_entry("1a86", "7523", ("7&3b74c78&0&1", "CH341SER_A64"))]
+    present = {_present("1a86", "7523", "7&3b74c78&0&1")}
+    assert udi.attached_devices(entries, present) == []
+
+
+# --- GUARD 2: a remembered INSTANCE of a device that IS attached -------------
+#
+# This is the one that fools the verification. The i1 Studio on this machine
+# really does hold two instance keys — two USB ports it has been plugged into —
+# and only one of them is present. `has_winusb` used to be OR-ed over both.
+
+def test_a_ghost_instance_does_not_lend_its_driver_to_a_live_one() -> None:
+    """Replug into another port: the new node is driverless, the old one still
+    says libusb0. If the stale one counts, wdi-simple's "exit 0" is confirmed by
+    a device that never bound and the user is told an install succeeded."""
+    entries = [_entry(
+        "0765", "6008",
+        ("7&3b74c78&0&2", "libusb0"),      # ghost: the old port
+        ("7&3b74c78&0&1", ""),             # live: no driver bound
+    )]
+    present = {_present("0765", "6008", "7&3b74c78&0&1")}
+    got = udi.attached_devices(entries, present)
+    assert [d.has_winusb for d in got] == [False], (
+        "a ghost instance's stale Service was counted as the live device's driver")
+
+
+def test_the_live_instance_is_believed_when_it_does_have_the_driver() -> None:
+    entries = [_entry(
+        "0765", "6008",
+        ("7&3b74c78&0&2", ""),             # ghost: the old port, driverless
+        ("7&3b74c78&0&1", "libusb0"),      # live: bound
+    )]
+    present = {_present("0765", "6008", "7&3b74c78&0&1")}
+    assert [d.has_winusb for d in udi.attached_devices(entries, present)] == [True]
+
+
+def test_a_present_device_whose_instances_do_not_match_is_kept() -> None:
+    """cfgmgr32 says this vid:pid is here; only the node is unrecognised. Keeping
+    it costs a possibly-stale driver flag, dropping it hides a real instrument —
+    and the second is the unsurvivable direction."""
+    entries = [_entry("0765", "6008", ("some&unexpected&form", "libusb0"))]
+    present = {_present("0765", "6008", "7&3b74c78&0&1")}
+    got = udi.attached_devices(entries, present)
+    assert [(d.vid, d.pid, d.has_winusb) for d in got] == [("0765", "6008", True)]
+
+
+def test_composite_children_collapse_to_one_device() -> None:
+    entries = [
+        ("VID_0765&PID_6008&MI_00", [("7&3b74c78&0&0000", "libusb0")]),
+        ("VID_0765&PID_6008", [("7&3b74c78&0&1", "libusb0")]),
+    ]
+    present = {r"USB\VID_0765&PID_6008&MI_00\7&3B74C78&0&0000",
+               r"USB\VID_0765&PID_6008\7&3B74C78&0&1"}
+    assert len(udi.attached_devices(entries, present)) == 1
+
+
+# --- and the whole point: the ghost never reaches the verification -----------
+
+def _win32_registry(monkeypatch, entries, present) -> None:
+    monkeypatch.setattr(udi, "sys", SimpleNamespace(platform="win32"))
+    monkeypatch.setattr(udi, "_registry_usb_entries", lambda: entries)
+    monkeypatch.setattr(udi, "present_usb_instance_ids", lambda: present)
+
+
+def test_a_ghost_never_reaches_unbound_targets(monkeypatch) -> None:
+    """THE BUG. `unbound_targets()` is the post-install verification — it must
+    not report "the driver did not bind" about hardware that is not attached."""
+    ghost = _dev("0765", "6008", has_winusb=False)
+    _win32_registry(
+        monkeypatch,
+        [_entry("0765", "6008", ("7&3b74c78&0&1", ""))],
+        set(),                                   # nothing is attached
+    )
+    assert udi.enumerate_connected() == []
+    assert udi.unbound_targets([ghost]) == []
+
+
+def test_a_genuinely_present_device_still_reaches_unbound_targets(monkeypatch) -> None:
+    """The other half of the guard: the filter must not swallow a real failure."""
+    target = _dev("0765", "6008", has_winusb=False)
+    _win32_registry(
+        monkeypatch,
+        [_entry("0765", "6008", ("7&3b74c78&0&1", ""))],
+        {_present("0765", "6008", "7&3b74c78&0&1")},
+    )
+    assert [(d.vid, d.pid) for d in udi.unbound_targets([target])] == [("0765", "6008")]
+
+
+def test_a_ghost_instance_cannot_confirm_an_install_that_did_not_happen(
+        monkeypatch) -> None:
+    """The false-SUCCESS direction, end to end: the live node is driverless, the
+    ghost node still says libusb0, and `unbound_targets()` must still say the
+    install did not bind."""
+    target = _dev("0765", "6008", has_winusb=False)
+    _win32_registry(
+        monkeypatch,
+        [_entry("0765", "6008",
+                ("7&3b74c78&0&2", "libusb0"),    # ghost
+                ("7&3b74c78&0&1", ""))],         # live, unbound
+        {_present("0765", "6008", "7&3b74c78&0&1")},
+    )
+    assert [(d.vid, d.pid) for d in udi.unbound_targets([target])] == [("0765", "6008")]
+
+
+def test_enumerate_connected_is_empty_off_windows(monkeypatch) -> None:
+    """The registry and cfgmgr32 do not exist there; importing must still work."""
+    monkeypatch.setattr(udi, "sys", SimpleNamespace(platform="darwin"))
+    assert udi.enumerate_connected() == []
+
+
+def test_presence_uses_the_cfgmgr32_present_filter() -> None:
+    """The constant's VALUE is the guard, and no stubbed test can reach it.
+
+    Every test above hands `attached_devices()` a presence set directly, so a
+    zero in either flag would leave them all green while the real call went back
+    to returning phantoms alongside the live device. Asserted from the source,
+    the same way `tests/test_ch34x_driver.py` pins the serial half.
+    """
+    module = inspect.getsource(udi)
+    assert "_CM_GETIDLIST_FILTER_PRESENT = 0x00000100" in module
+    assert "_CM_GETIDLIST_FILTER_ENUMERATOR = 0x00000001" in module
+
+    fn = inspect.getsource(udi.present_usb_instance_ids)
+    assert "_CM_GETIDLIST_FILTER_ENUMERATOR | _CM_GETIDLIST_FILTER_PRESENT" in fn
+    assert "CM_Get_Device_ID_ListW" in fn
+
+
+def test_the_registry_read_does_no_filtering_of_its_own() -> None:
+    """One filter, in one place. `_registry_usb_entries()` reports what is
+    REMEMBERED; if it started deciding what is present there would be two
+    answers to the same question and they could drift apart."""
+    src = inspect.getsource(udi._registry_usb_entries)
+    for forbidden in ("present", "PRESENT", "cfgmgr"):
+        assert forbidden not in src.split('"""')[2], (
+            f"{forbidden} appears in the registry read; presence is "
+            "attached_devices()'s job")

--- a/ui/dialogs/settings_dialog.py
+++ b/ui/dialogs/settings_dialog.py
@@ -65,104 +65,18 @@ from core.i18n import tr
 # Which of those devices is actually plugged in
 # ---------------------------------------------------------------------------
 #
-# `core.usb_driver_installer.enumerate_connected()` reads
-# HKLM\SYSTEM\CurrentControlSet\Enum\USB, and that key is a MEMORY, not a
-# census: Windows keeps a subkey for every USB device the machine has ever
-# seen, for ever. So the dialog has been saying "Connected colorimeter: X-Rite
-# i1 Studio" on a machine with nothing whatsoever plugged into it — measured on
-# this ARM64 box on 2026-09-04, where the only USB devices present were the
-# virtual-machine's own and one CH340.
+# THE PRESENCE FILTER USED TO LIVE HERE, AND THAT WAS THE BUG.
+# `HKLM\SYSTEM\CurrentControlSet\Enum\USB` remembers every USB device this
+# machine has ever seen, so this window once said "Connected colorimeter:
+# X-Rite i1 Studio" with nothing plugged in. The fix filtered the answer here,
+# beside this one caller — which left `unbound_targets()`, the OTHER caller of
+# `enumerate_connected()` and the one whose whole job is to not be fooled,
+# still reading ghosts.
 #
-# That is not a cosmetic wart. The whole point of the window is to tell you what
-# state your instrument is in; a box that names hardware you do not own poisons
-# every sentence under it, including the new ones.
-#
-# The fix is to ask configuration manager which device nodes are PRESENT, which
-# is a different question from which are remembered. `CM_Get_Device_ID_ListW`
-# with CM_GETIDLIST_FILTER_PRESENT answers it directly, and it is the same
-# presence source `core/ch34x_driver.py` uses for the serial side, so the two
-# halves of this window cannot disagree about what "attached" means.
-#
-# NOTE ON THE FAILURE DIRECTION. When the question cannot be asked at all — not
-# Windows, no cfgmgr32, the call fails — `present_usb_ids()` returns None and
-# the filter lets everything through. A ghost in the list is a lie the user can
-# see and ignore. A real instrument filtered OUT of the list is a working
-# feature that silently refuses to help. Of the two, only the first is
-# survivable, so the fallback is deliberately the noisy one.
-
-#: `CM_GETIDLIST_FILTER_ENUMERATOR` — restrict to the "USB" enumerator.
-_CM_GETIDLIST_FILTER_ENUMERATOR = 0x00000001
-#: `CM_GETIDLIST_FILTER_PRESENT` — the whole point: attached right now.
-_CM_GETIDLIST_FILTER_PRESENT = 0x00000100
-_CR_SUCCESS = 0
-
-
-def usb_ids_in_instance(instance_id: str) -> "tuple[str, str] | None":
-    r"""The (vid, pid) inside a PnP instance ID, lower-case, or None.
-
-    ``USB\VID_1A86&PID_7523\7&3b74c78&0&1`` → ``("1a86", "7523")``.
-    Composite children carry a third token (``&MI_00``) and hubs carry no VID
-    at all (``USB\ROOT_HUB30\…``); both are handled by looking for the tokens
-    rather than counting them.
-    """
-    parts = instance_id.split("\\")
-    if len(parts) < 2:
-        return None
-    vid = pid = None
-    for token in parts[1].upper().split("&"):
-        if token.startswith("VID_"):
-            vid = token[4:].lower()
-        elif token.startswith("PID_"):
-            pid = token[4:].lower()
-    if vid is None or pid is None:
-        return None
-    return vid, pid
-
-
-def present_usb_ids() -> "set[tuple[str, str]] | None":
-    """Every (vid, pid) attached to this machine right now.
-
-    None means the question could not be asked — see the note above: callers
-    must then show everything rather than hide anything.
-    """
-    if _sys.platform != "win32":
-        return None
-    try:
-        import ctypes
-        cfgmgr = ctypes.WinDLL("cfgmgr32")
-        flags = ctypes.c_ulong(
-            _CM_GETIDLIST_FILTER_ENUMERATOR | _CM_GETIDLIST_FILTER_PRESENT)
-        enumerator = ctypes.c_wchar_p("USB")
-        size = ctypes.c_ulong(0)
-        if cfgmgr.CM_Get_Device_ID_List_SizeW(
-                ctypes.byref(size), enumerator, flags) != _CR_SUCCESS:
-            return None
-        buf = ctypes.create_unicode_buffer(size.value)
-        if cfgmgr.CM_Get_Device_ID_ListW(
-                enumerator, buf, size, flags) != _CR_SUCCESS:
-            return None
-        raw = buf[:size.value]
-    except Exception as exc:   # noqa: BLE001 — a missing DLL must not kill the window
-        log.warning("could not ask Windows which USB devices are present: %s", exc)
-        return None
-
-    found: set[tuple[str, str]] = set()
-    for instance_id in raw.split("\0"):
-        if not instance_id:
-            continue
-        ids = usb_ids_in_instance(instance_id)
-        if ids is not None:
-            found.add(ids)
-    return found
-
-
-def attached_only(devices, present_ids: "set[tuple[str, str]] | None"):
-    """Drop the devices Windows remembers but no longer has."""
-    if present_ids is None:
-        return list(devices)
-    return [d for d in devices
-            if (str(d.vid).lower(), str(d.pid).lower()) in present_ids]
-
+# It now lives in `core.usb_driver_installer`, inside `enumerate_connected()`
+# itself, at instance granularity. `enumerate_connected()` means connected.
+# There is nothing left for this window to filter, and deliberately no second
+# copy here that could drift away from the first.
 
 
 # ---------------------------------------------------------------------------
@@ -5863,11 +5777,10 @@ class SettingsDialog(QDialog):
         offer_anyway = False
 
         while True:
-            # enumerate_connected() reads a registry key that remembers every
-            # USB device this machine has EVER seen, so it must be filtered
-            # against what is attached right now or the window names hardware
-            # the user does not own.
-            devices = attached_only(enumerate_connected(), present_usb_ids())
+            # enumerate_connected() returns what is ATTACHED, not what the
+            # registry remembers — it filters against cfgmgr32's PRESENT list
+            # itself, so this window names no hardware the user does not own.
+            devices = enumerate_connected()
             needs_install = [d for d in devices if not d.has_winusb]
             states = self._serial_states()
 
@@ -5985,12 +5898,11 @@ class SettingsDialog(QDialog):
                 # previous USB port can misdirect it. Verify by re-enumerating
                 # before claiming success, and fall back to Zadig if it didn't bind.
                 #
-                # unbound_targets() re-enumerates through the same remembering
-                # registry key, so the same presence filter applies: a ghost with
-                # no driver would otherwise be reported as "the install did not
-                # bind" on a perfectly good install.
-                still_unbound = attached_only(unbound_targets(targets),
-                                              present_usb_ids())
+                # unbound_targets() re-enumerates through enumerate_connected(),
+                # which is now presence-filtered at instance level, so a ghost
+                # can neither be reported as "the install did not bind" nor lend
+                # its stale driver to a device that did not bind at all.
+                still_unbound = unbound_targets(targets)
                 outcome_text, offer_zadig = usb_install_outcome(
                     wdi_available=True,
                     ran_ok=ran_ok,


### PR DESCRIPTION
## The bug, caught on real hardware

Found while testing the **Argyll-native** driver-install path with a real instrument for the first time — the CR30's path had been tested with care, this one never had.

With Basti's ColorMunki (i1Studio, `USB\VID_0765&PID_6008`) deliberately left driverless:

```
PRESENT  USB\VID_0765&PID_6008\7&3B74C78&0&1   Service=''          <- the real device, NO driver
GHOST    USB\VID_0765&PID_6008\7&3B74C78&0&2   Service='libusb0'   <- a stale entry from an old USB port
```

`enumerate_connected()` walked **every** registry instance under the VID/PID and set `has_winusb=True` if *any* of them carried the service, without ever asking whether that instance was present. So:

```
master:  has_winusb=True   -> "the driver is already installed", no Install button
         unbound_targets() -> []
fixed:   has_winusb=False  -> "driver not installed", button: Install Driver
         unbound_targets() -> [('0765','6008')]
```

Argyll saw `** No ports found **` the whole time. The user is told the driver is fine while the instrument is invisible, **and is offered no way to install it** — a closed loop with no exit from inside the app.

`unbound_targets()`'s own docstring already warned that *"a stale ghost instance from a previous USB port can misdirect it"*. The hazard was written down and only half of it was guarded.

## Two reproductions

**Instance-level** — the one above, confirmed live on the bench.

**List-level** — the registry remembered 6 vid:pid, cfgmgr32 said 5 were present. Give the absent one a name in `KNOWN_COLORIMETERS` and it walks straight out, and `unbound_targets()` reports "the driver did not bind" about hardware that is not in the building.

Granularity is **per instance**, not per (vid,pid): a (vid,pid) filter would have passed the live bug straight through, because the device *is* present — only its old port isn't.

## Where the fix went, and what was rejected

Inside `enumerate_connected()`, with the single presence implementation moved into `core/usb_driver_installer.py` and **the dialog's duplicate copy deleted**. The name is the argument: the function promises *connected* and delivered *remembered*, so any fix that leaves that promise broken is one the next caller has to know about — and there were already two callers, one of which didn't.

Rejected: filtering only in `unbound_targets()` (leaves the trap armed for caller three); a `present_only=` flag (a default-True switch for turning the truth off — and the one legitimate "show everything" case is *presence unknown*, which is already `None`); keeping both copies (two cfgmgr32 calls, two failure policies, one question — the exact drift this repo has already paid for once).

## Proof the tests are load-bearing — 7/7 mutations killed

| mutation | first red |
|---|---|
| GUARD 1 dropped / inverted | `test_a_remembered_device_that_is_not_attached_is_dropped` |
| GUARD 2 removed / fallback swallows it | `test_a_ghost_instance_does_not_lend_its_driver_to_a_live_one` |
| failure direction inverted | `test_when_windows_cannot_be_asked_everything_is_shown` |
| `_CM_GETIDLIST_FILTER_PRESENT = 0` | `test_presence_uses_the_cfgmgr32_present_filter` |
| `enumerate_connected()` stops filtering | `test_a_ghost_never_reaches_unbound_targets` |

When Windows cannot be asked, everything is shown — the failure direction is deliberate and pinned.

## Test results

`tests/test_usb_driver_installer.py` + `test_usb_driver_dialog.py` + `test_ch34x_driver.py`, rebased onto `38ed485d`: **572 passed, 1 failed**.

The one failure is `test_the_consent_buttons_fit_the_row_in_every_language`, and it is **pre-existing and nondeterministic**. On unmodified `origin/master`, same command, three consecutive runs: `13 passed`, `13 passed`, then `4 failed` (`zh_CN` among them). Across runs on this branch the failing language was `fr`, then `no`, then `ru`, then `no` — *the parametrisation changes run to run on identical code*. Nothing here touches a string or a layout. It is the offscreen font-metric problem being fixed separately on `proposed/offscreen-font-metrics`.

## Two things to flag

**Two further copies of this cfgmgr32 call remain** — `core/ch34x_driver.py::_present_usb_instance_ids()` and `core/argyll_instruments.py::_windows_usb_devices()`. Consolidating them is right and was deliberately left out of this commit: ch34x returns `[]` where this returns `None` (a different, deliberate failure policy), `argyll_instruments` returns int-keyed records, and `tests/test_ch34x_driver.py` asserts on that module's own source. Follow-up.

**Expect a conflict with `fix/driver-dialog-says-what-it-does`**, which also edits `ui/dialogs/settings_dialog.py`. Land this one first; that branch will be rebased on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXFQwMgD9Uc6ZfySU2gXKB
