### PR TITLE
The geometry tests were measuring a font that does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ assets/app_icon.ico
 # person who ran it — their devices and their neighbours'. The script writes to
 # the Desktop now, but belt and braces: never commit one from anywhere.
 cr30-bluetooth-report*.txt
+scripts/offscreen_font_probe/_results/

--- a/scripts/offscreen_font_probe/measure.py
+++ b/scripts/offscreen_font_probe/measure.py
@@ -1,0 +1,89 @@
+"""Measurement harness for the offscreen-font-metrics question (Windows gate).
+
+Runs a set of test files serially under QT_QPA_PLATFORM=offscreen, records the
+per-test outcome of every one via JUnit XML, and diffs two such recordings so a
+BEFORE/AFTER delta can be reported instead of two absolutes.
+
+    python scripts/offscreen_font_probe/measure.py run  <label> <file> [file...]
+    python scripts/offscreen_font_probe/measure.py diff <before-label> <after-label>
+
+`diff` reports, separately:
+  fixed    — failed BEFORE, passes AFTER
+  broken   — passed BEFORE, fails AFTER   (the number that matters)
+  still    — failed in both
+Nothing here changes an assertion; it only records what the suite already says.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+OUT = Path(os.environ.get("A3_OUT", Path(__file__).resolve().parent / "_results"))
+
+
+def _outcomes(xml_path: Path) -> dict[str, str]:
+    root = ET.parse(xml_path).getroot()
+    out: dict[str, str] = {}
+    for case in root.iter("testcase"):
+        nid = f"{case.get('classname')}::{case.get('name')}"
+        state = "passed"
+        for child in case:
+            tag = child.tag
+            if tag in ("failure", "error"):
+                state = tag
+            elif tag == "skipped":
+                state = "skipped"
+        out[nid] = state
+    return out
+
+
+def run(label: str, files: list[str]) -> int:
+    OUT.mkdir(parents=True, exist_ok=True)
+    xml = OUT / f"{label}.xml"
+    env = dict(os.environ, QT_QPA_PLATFORM="offscreen")
+    env.pop("PYTHONUTF8", None)            # the gate does not set it; nor do we
+    # Serial on purpose: two cores, shared with another agent. `-p no:xdist`
+    # cannot be used because pytest.ini's addopts carry xdist flags, so ask for
+    # zero workers instead.
+    cmd = [sys.executable, "-m", "pytest", "-q", "--tb=no", "-n", "0",
+           f"--junit-xml={xml}", *files]
+    proc = subprocess.run(cmd, env=env, cwd=Path(__file__).resolve().parents[2])
+    res = _outcomes(xml)
+    (OUT / f"{label}.json").write_text(json.dumps(res, indent=1), encoding="utf-8")
+    tally: dict[str, int] = {}
+    for v in res.values():
+        tally[v] = tally.get(v, 0) + 1
+    print(f"\n[{label}] {tally}  (pytest exit {proc.returncode})")
+    return 0
+
+
+def diff(before: str, after: str) -> int:
+    b = json.loads((OUT / f"{before}.json").read_text(encoding="utf-8"))
+    a = json.loads((OUT / f"{after}.json").read_text(encoding="utf-8"))
+    bad = {"failure", "error"}
+    fixed = sorted(n for n, s in b.items() if s in bad and a.get(n) == "passed")
+    broken = sorted(n for n, s in b.items() if s == "passed" and a.get(n) in bad)
+    still = sorted(n for n, s in b.items() if s in bad and a.get(n) in bad)
+    gone = sorted(set(b) - set(a))
+    new = sorted(set(a) - set(b))
+    print(f"BEFORE={before} n={len(b)}  AFTER={after} n={len(a)}")
+    print(f"  fixed  (failed -> passed): {len(fixed)}")
+    print(f"  broken (passed -> failed): {len(broken)}")
+    print(f"  still failing            : {len(still)}")
+    for title, rows in (("FIXED", fixed), ("BROKEN", broken), ("STILL", still),
+                        ("ONLY-BEFORE", gone), ("ONLY-AFTER", new)):
+        if rows:
+            print(f"\n--- {title} ({len(rows)}) ---")
+            for r in rows:
+                print("   ", r)
+    return 0
+
+
+if __name__ == "__main__":
+    if sys.argv[1] == "run":
+        raise SystemExit(run(sys.argv[2], sys.argv[3:]))
+    raise SystemExit(diff(sys.argv[2], sys.argv[3]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,25 @@ def _one_qapplication_per_worker():
     from PyQt6.QtWidgets import QApplication
 
     _PINNED_QAPP = QApplication.instance() or QApplication([])
+    # REGISTER THE FONTS THE APP BUNDLES, in the same position `main()` does
+    # (main.py:143, immediately before `setStyle`). Under
+    # `QT_QPA_PLATFORM=offscreen` on Windows `QFontDatabase.families()` is
+    # EMPTY, so every family the stylesheet asks for (`ui/styles.py` asks for
+    # Inter everywhere) draws as a tofu box of `pixelSize`: w('i') == w('W').
+    # "Manuelle Einstellungen" then measures 286 px against 144 px of real
+    # Inter — a 1.99x overestimate under every widget on the screen.
+    # ORDER MATTERS ON macOS: once anything has populated the CoreText font
+    # database, `addApplicationFont` returns -1 for a family that is already
+    # there. Registering here, before the first `families()` call any test
+    # makes, is the only position where it takes.
+    try:
+        import os as _os
+        _repo = _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__)))
+        from PyQt6.QtGui import QFontDatabase as _QFD
+        for _f in sorted(pathlib.Path(_repo, "assets", "fonts").glob("*.ttf")):
+            _QFD.addApplicationFont(str(_f))
+    except Exception:                                    # pragma: no cover
+        pass          # fonts dir missing — the suite falls back as main() does
     try:
         _PINNED_QAPP.setStyle("Fusion")
     except Exception:                                    # pragma: no cover

--- a/tests/test_a_long_label_is_not_clipped_by_its_indent.py
+++ b/tests/test_a_long_label_is_not_clipped_by_its_indent.py
@@ -116,11 +116,35 @@ def test_the_stamp_tick_box_shows_its_whole_label(qapp, lang, tmp_path):
 
 
 def test_this_file_can_see_the_bug_it_guards(qapp, tmp_path):
-    """Control. Pin the indent back to a fixed width and German must fail again
-    — otherwise the assertions above would hold against any layout at all."""
+    """Control. Pin the indent back to a fixed width and the longest language
+    must be clipped again — otherwise the assertions above would hold against
+    any layout at all.
+
+    RUSSIAN, NOT GERMAN, AND THE LANGUAGE IS THE WHOLE CALIBRATION. This
+    control was written against the Windows offscreen gate's tofu metrics,
+    where every glyph was a box of `pixelSize` and German measured 297 px
+    against the 294 the pinned row leaves. With the fonts the app actually
+    bundles registered (`tests/conftest.py`), the same German label measures
+    **208 px and the pinned row leaves exactly 208** — the control failed on
+    `assert 208 < 208`, an exact tie, and would have flipped on a one-pixel
+    rounding change in either direction.
+
+    Measured here, every language, pinned-row width against the label's own
+    minimum (Inter, this tree, 2026-09-06):
+
+        ru 289 / 317  -28      de 208 / 208   0      nl 205 / 205   0
+        sv 241 / 241    0      no 215 / 215   0      en 156 / 156   0
+
+    Only Russian is genuinely clipped — by 28 px, which is a margin and not a
+    tie. It is also the language this file's own header already names as the
+    widest ("Russian needs 331 px against English's 225"), so the control now
+    runs in the language it was always describing. German is left to the
+    parametrised assertions above, where it belongs: at 208/208 the shipped
+    layout gives that label exactly what it needs and not a pixel more.
+    """
     from PyQt6.QtWidgets import QLabel
 
-    tab, cb = _stamp_check(qapp, "de", tmp_path)
+    tab, cb = _stamp_check(qapp, "ru", tmp_path)
     try:
         row = tab._manual_stamp_cmd_row
         spacer = row.layout().itemAt(0).widget()
@@ -131,8 +155,9 @@ def test_this_file_can_see_the_bug_it_guards(qapp, tmp_path):
         row.layout().activate()
         qapp.processEvents()
         assert cb.width() < cb.minimumSizeHint().width(), (
-            "pinning the indent back did NOT clip the German label, so the "
-            "assertions above are not measuring the indent")
+            f"pinning the indent back did NOT clip the Russian label "
+            f"({cb.width()} px given, {cb.minimumSizeHint().width()} px "
+            f"needed), so the assertions above are not measuring the indent")
     finally:
         # Deliberately NOT deleted — see _KEEP_ALIVE.
         qapp.processEvents()

--- a/tests/test_button_rows_do_not_overlap.py
+++ b/tests/test_button_rows_do_not_overlap.py
@@ -143,8 +143,25 @@ def test_the_stylesheet_rule_carries_the_TEXT_width(qapp):
     padding and border on top. Writing the already-padded figure there counted
     ``padding: 6px 18px`` twice, so a button asking for 140 px got a 178 px
     minimum. Four of those do not fit a 580 px panel, and Qt overlapped them.
+
+    …AND THE FLOOR IS PART OF THE RULE, WHICH THIS TEST USED TO DENY.
+    `fit_button_width` writes ``max(needed + 2, _APP_MIN_BUTTON_WIDTH)``
+    (`ui/widgets.py:318`) — the app's own standard button width, deliberately,
+    because without it the "✕" that closes the gamut view shrank from 72 px to
+    ten pixels' worth of content box. A `text <= declared <= text + 2` bound
+    says that floor is a bug.
+
+    It passed anyway for exactly one reason: under `QT_QPA_PLATFORM=offscreen`
+    on Windows the font database was EMPTY, every glyph was a box of
+    `pixelSize`, and the fake text was always wide enough to push past 72 px.
+    With the bundled fonts registered, "Print / Current Page" measures **65 px**
+    of real Inter, `fit` correctly declares **72**, and the old bound failed on
+    `assert 72 <= 67`. The app is right and the test was wrong; the floor is
+    now in the bound, and the "padding counted twice" fault it was written for
+    (140 px of text → 178 px declared) still fails it.
     """
     import re
+    from ui.widgets import _APP_MIN_BUTTON_WIDTH
     host = QWidget()
     b = QPushButton("Print\nCurrent Page", host)
     ButtonFontFilter.fit(b)
@@ -152,10 +169,11 @@ def test_the_stylesheet_rule_carries_the_TEXT_width(qapp):
     assert rule, b.styleSheet()
     declared = int(rule.group(1))
     text = _needed(b)
-    assert text <= declared <= text + 2, (
-        f"the rule declares {declared}px for {text}px of text — anything more "
-        f"than a pixel or two of rounding tolerance is padding counted a "
-        f"second time")
+    assert text <= declared <= max(text + 2, _APP_MIN_BUTTON_WIDTH), (
+        f"the rule declares {declared}px for {text}px of text (floor "
+        f"{_APP_MIN_BUTTON_WIDTH}px) — anything more than a pixel or two of "
+        f"rounding tolerance above the greater of the two is padding counted "
+        f"a second time")
 
 
 def test_the_effective_minimum_is_still_enough_for_the_text(qapp):

--- a/tests/test_no_chart_preview_guidance.py
+++ b/tests/test_no_chart_preview_guidance.py
@@ -84,10 +84,23 @@ def test_profile_run_combo_is_readable_width(qapp, tmp_path):
     # offscreen Qt on Windows the font database is EMPTY: every family resolves
     # to a null font, the combo sizes itself from nothing, and this measured 117
     # against a threshold of 120 — failing on an un-measurable number rather
-    # than on anything wrong. It passes with real fonts. Same guard as the
-    # eleven other advance-measuring files (2026-08-22, Windows gate).
+    # than on anything wrong. Same guard as the eleven other advance-measuring
+    # files (2026-08-22, Windows gate).
+    #
+    # …AND THE THRESHOLD WAS A GLYPH MEASUREMENT TOO, WHICH IS WHY IT IS GONE.
+    # `ui/measurement_target_bar.py:795` sets the floor to
+    # `fontMetrics().horizontalAdvance("Run 8 (overwrite)") + 44`, so a flat
+    # 120 px pins the FONT, not the combo: with ChromIQ's own fonts registered
+    # the same string measures 73 px of real Inter, the app correctly asks for
+    # 117, and 120 failed a combo that is exactly as comfortable as it was on
+    # the metrics the constant came from. The bound below is the label plus the
+    # dropdown chrome, measured in the combo's own font — which is what "fits
+    # 'Run N (overwrite)' comfortably" actually means, on any metrics.
     skip_without_fonts()
     tab, ctl = _tab_with_project(tmp_path)
     bar = MeasurementTargetBar(ctl)
+    label_px = bar._run_combo.fontMetrics().horizontalAdvance("Run 8 (overwrite)")
     # Comfortably fits "Run N (overwrite)" plus the dropdown chrome.
-    assert bar._run_combo.minimumWidth() >= 120
+    assert bar._run_combo.minimumWidth() >= label_px + 40, (
+        f"the run combo's floor is {bar._run_combo.minimumWidth()} px for a "
+        f"{label_px} px label — no room left for the dropdown arrow")

--- a/tests/test_report_pdf_layout.py
+++ b/tests/test_report_pdf_layout.py
@@ -102,9 +102,25 @@ def test_two_straddlers_resolve_independently(qapp):
 
 
 def test_wrapped_legend_gets_its_own_rows(qapp):
-    """At the PDF grab width the five ΔE labels wrap to two legend rows; at a
-    wide window they fit one. The row count is what moves the plot down, so a
-    wrapped legend can never be painted across the graph."""
+    """A legend too narrow for its five ΔE labels takes more than one row; a
+    wide one takes exactly one. The row count is what moves the plot down, so a
+    wrapped legend can never be painted across the graph.
+
+    THE NARROW WIDTH IS MEASURED, NOT ASSUMED, AND THAT IS THE CHANGE HERE.
+    This asked for two rows at the 640 px PDF grab width, a figure taken on the
+    Windows offscreen gate with an EMPTY font database, where every glyph is a
+    box of `pixelSize` and five labels could not possibly fit. With ChromIQ's
+    own fonts registered the same five labels measure 82 + 84 + 84 + 90 + 92 =
+    **432 px** at `pixelSize(10)` and fit the 588 px the PDF grab leaves on ONE
+    row — so `narrow >= 2` failed on `assert 1 >= 2` at a width where the app
+    is behaving correctly. Measured on this tree, 2026-09-06, rows against the
+    available width: 200 → 5, 260 → 3, 340 → 2, 560 → 2, 600 → 1.
+
+    The wrapping threshold therefore moves with the font, and pinning a pixel
+    figure to it pins the font. The width below is derived from the labels
+    themselves, so the assertion says what it means on any metrics; the PDF
+    grab width is kept as a separate, explicit statement of what it now does.
+    """
     from PyQt6.QtGui import QColor, QFont, QFontMetricsF
     from ui.dialogs.measurement_report_dialog import _TrendChart
     chart = _TrendChart()
@@ -115,10 +131,19 @@ def test_wrapped_legend_gets_its_own_rows(qapp):
     font = QFont()
     font.setPixelSize(10)
     fm = QFontMetricsF(font)
-    narrow = chart._legend_rows(fm, 40.0, 640 - 52.0)
+    # Half of what the five labels' own glyphs need: whatever the font, that
+    # cannot be one row.
+    too_narrow = sum(fm.horizontalAdvance(l) for l in labels) / 2.0
+    narrow = chart._legend_rows(fm, 40.0, too_narrow)
     wide = chart._legend_rows(fm, 40.0, 1600 - 52.0)
-    assert narrow >= 2, narrow
+    assert narrow >= 2, (narrow, too_narrow)
     assert wide == 1, wide
+    # …and the plot really is pushed down by the extra rows, which is the whole
+    # point of counting them.
+    assert chart._legend_rows(fm, 40.0, too_narrow / 2.0) > narrow
+    # What the PDF grab width does today, said out loud so a regression in
+    # either direction is visible: the labels fit one row there.
+    assert chart._legend_rows(fm, 40.0, 640 - 52.0) == 1
 
 
 def test_trend_chart_paints_at_pdf_width(qapp):

--- a/tests/test_the_manual_panel_does_not_scroll_sideways.py
+++ b/tests/test_the_manual_panel_does_not_scroll_sideways.py
@@ -291,22 +291,72 @@ def test_the_filter_that_makes_labels_cost_something_is_on(qapp, tmp_path):
     """Control — prove the measurement can SEE a long label at all.
 
     Not a proxy: the number checked is the one the packing uses. A German
-    "Auf Vorgabe zurücksetzen" must arrive at the layout as a >=200 px floor.
-    Without `CompositeAppFilter` it arrives as 94 px — the app stylesheet's flat
-    72 px content box plus padding and border — in every language, and the whole
-    file becomes an expensive way of measuring nothing.
+    "Auf Vorgabe zurücksetzen" must arrive at the layout carrying its own
+    label's width. Without `CompositeAppFilter` it arrives as the app
+    stylesheet's flat `_APP_MIN_BUTTON_WIDTH` content box plus padding and
+    border — the same number in every language — and the whole file becomes an
+    expensive way of measuring nothing.
+
+    THE BOUND IS THE LABEL, NOT A CONSTANT, AND THAT IS THE FIX HERE. This
+    read `floor >= 200`, a figure taken on macOS where `Menlo` — the family
+    `ButtonFontFilter` asks for — actually exists. It does not exist on
+    Windows, and under `QT_QPA_PLATFORM=offscreen` with only ChromIQ's own
+    three bundled faces in the database it resolves to `Instrument Serif`, so
+    the same German label reaches the layout as **166 px**: the filter is doing
+    its job and the constant said it was not. Measured on this tree,
+    2026-09-06, German: label advance in the button's own font **142 px**,
+    fitted `min-width` rule **144 px**, floor **166 px**, against
+    `_APP_MIN_BUTTON_WIDTH` **72** and a one-character button's rule of exactly
+    that 72. The assertions below pin the mechanism instead — the rule is
+    written, it is the LABEL's width and not the flat floor, and it reaches the
+    layout — which fails on the regression this control guards in every
+    language and on every platform, where a magic 200 only failed on one.
     """
+    import re
+    from ui.widgets import _APP_MIN_BUTTON_WIDTH
+    from PyQt6.QtGui import QFontMetrics
+
     tab, _area = _manual_scroll_area(qapp, "de", tmp_path)
     try:
         btn = tab._manual_preset_reset_btn
         assert btn.text() == "Auf Vorgabe zurücksetzen", btn.text()
+        rule = re.search(r"min-width:\s*(\d+)px", btn.styleSheet())
+        assert rule, (
+            f"ButtonFontFilter has written no per-label min-width rule on "
+            f"'Auf Vorgabe zurücksetzen', so no label in any language can "
+            f"widen this pane and every assertion in this file is vacuous: "
+            f"{btn.styleSheet()!r}")
+        declared = int(rule.group(1))
+        assert declared > _APP_MIN_BUTTON_WIDTH, (
+            f"the rule on 'Auf Vorgabe zurücksetzen' declares {declared} px — "
+            f"the flat {_APP_MIN_BUTTON_WIDTH} px floor every button gets, not "
+            f"this label's own width. Nothing in this file can then be widened "
+            f"by a translation")
+        label_px = QFontMetrics(btn.font()).horizontalAdvance(btn.text().upper())
+        assert declared >= label_px, (
+            f"the rule declares {declared} px for a label that measures "
+            f"{label_px} px in the button's own font")
         floor = btn.minimumSizeHint().width()
-        assert floor >= 200, (
-            f"the German 'Auf Vorgabe zurücksetzen' reaches the layout as a "
-            f"{floor} px floor. ButtonFontFilter has not written its per-label "
-            f"min-width rule, so no label in any language can widen this pane "
-            f"and every assertion in this file is vacuous")
+        assert floor >= declared, (
+            f"the {declared} px rule does not reach the layout: the button's "
+            f"floor is {floor} px")
         assert btn.font().capitalization() == btn.font().capitalization().AllUppercase
+        # …AND THE ROW MUST STILL WRAP RATHER THAN SUM. The other half of
+        # `test_this_file_can_see_the_preset_row_running_off_the_edge`, taken
+        # here because this test already has an unmutated German tab and a
+        # second `TabChart` build is the expensive, fault-prone part of this
+        # file. `WrappingButtonRow` charges the row its widest SINGLE button;
+        # a plain `QHBoxLayout` charges the sum, which is the fault the owner
+        # reported five times.
+        widths = [b.minimumSizeHint().width()
+                  for b in (tab._manual_preset_reset_btn,
+                            tab._manual_preset_update_btn,
+                            tab._manual_preset_edit_btn)]
+        row_floor = tab._manual_preset_bar.minimumSizeHint().width()
+        assert row_floor <= max(widths) + 2, (
+            f"the shipped preset row costs {row_floor} px for buttons of "
+            f"{widths} — it is no longer wrapping, so a long label can widen "
+            f"this pane again")
     finally:
         tab.deleteLater()
         qapp.processEvents()
@@ -317,8 +367,44 @@ def test_this_file_can_see_the_preset_row_running_off_the_edge(qapp, monkeypatch
     """Control — the fault the owner reported five times, put back.
 
     The row used to be a plain `QHBoxLayout`, whose minimum is the SUM of its
-    three buttons: 592 px in German against a 540 px viewport. Substitute that
-    layout back and the file must fail; if it does not, the guard is decoration.
+    three buttons. Substitute that layout back and the difference must show; if
+    it does not, `WrappingButtonRow` is decoration.
+
+    WHAT THIS ASSERTED, AND WHY IT NO LONGER CAN. It read `hbar.maximum() > 0`
+    on the German pane: the sum was 592 px against a 540 px viewport. That 592
+    was measured on the Windows offscreen gate with an EMPTY font database,
+    where every glyph is a box of `pixelSize`. With ChromIQ's own fonts
+    registered the three German labels measure 166 + 144 + 144, the plain row's
+    minimum is **466 px**, and the German pane's content minimum is 537 px
+    either way — the row is no longer the widest thing in that column, so the
+    pane does not overflow and `maximum()` stays 0. Measured for every shipped
+    language on this tree, 2026-09-06, plain-row content minimum against the
+    540 px viewport: de 537, sv 536, ru 531, pl 526, no 520, pt 520, es 514,
+    it 504, fr 490, en 449, ja 416, zh_CN 416 — **not one of them crosses 540**
+    (nl is 544, but nl is over budget with the shipped row too: see
+    `test_the_manual_panel_never_scrolls_sideways[nl-engine]`). There is no
+    language left in which this mutation overflows the pane, so no choice of
+    language can recalibrate the old assertion.
+
+    So the control asserts the MECHANISM the mutation changes, which holds on
+    every platform and in every language: a plain `QHBoxLayout` charges the row
+    the SUM of its buttons. That is what `WrappingButtonRow` exists to prevent,
+    and reverting it fails here immediately rather than only where the sum
+    happens to exceed the pane. The other half — that the SHIPPED row is
+    charged only its widest single button — is asserted by
+    `test_the_filter_that_makes_labels_cost_something_is_on`, which already has
+    an unmutated German tab in hand and so costs no second build. Measured on
+    this tree: German shipped 166 px, plain 466 px, buttons 166/144/144.
+
+    ONE TAB, NOT TWO, AND THAT IS DELIBERATE. `TabChart` construction is the
+    expensive and fragile part of this file — building 42 of them already
+    faulted a worker once here with a Windows access violation inside
+    `_build_ui` — so this control takes both of its numbers from the single
+    mutated build.
+
+    The file's `hbar.maximum()` instrument is still proved able to see an
+    over-wide pane — by `test_this_file_can_see_the_fault_it_guards` above,
+    which mutates `ElidingComboBox` and is green.
 
     Patched on `ui.widgets`, not on `tab_chart`: `_make_manual_panel` imports
     the name inside the function, so the module attribute is what it resolves.
@@ -329,14 +415,30 @@ def test_this_file_can_see_the_preset_row_running_off_the_edge(qapp, monkeypatch
     from PyQt6.QtWidgets import QHBoxLayout
 
     import ui.widgets as uiw
+
+    def _row_and_buttons(tab):
+        bar = tab._manual_preset_bar
+        widths = [b.minimumSizeHint().width()
+                  for b in (tab._manual_preset_reset_btn,
+                            tab._manual_preset_update_btn,
+                            tab._manual_preset_edit_btn)]
+        return bar.minimumSizeHint().width(), widths
+
     monkeypatch.setattr(uiw, "WrappingButtonRow", QHBoxLayout, raising=True)
     tab, area = _manual_scroll_area(qapp, "de", tmp_path)
     try:
-        over = area.horizontalScrollBar().maximum()
-        assert over > 0, (
-            "with the preset row back on a plain QHBoxLayout the German Manual "
-            "panel still fits its viewport, so this file would not have caught "
-            "the fault it was extended for")
+        assert type(tab._manual_preset_bar.layout()) is QHBoxLayout, (
+            "the substitution did not land — this control is measuring the "
+            "shipped row and proves nothing")
+        plain, widths = _row_and_buttons(tab)
+        assert plain >= sum(widths), (
+            f"a plain QHBoxLayout does not charge the row the sum of its "
+            f"buttons ({plain} px for {widths}), so this control is not "
+            f"re-creating the fault it was written for")
+        assert plain > max(widths) + 2, (
+            f"the plain row costs {plain} px, no more than its widest single "
+            f"button of {widths} — there is nothing here for "
+            f"`WrappingButtonRow` to have saved")
     finally:
         tab.deleteLater()
         qapp.processEvents()

--- a/tests/test_usb_driver_dialog.py
+++ b/tests/test_usb_driver_dialog.py
@@ -2016,10 +2016,54 @@ def test_the_not_bound_window_is_unchanged_when_core_says_nothing():
 # and, when the cap is what bit, everything is still reachable by scrolling.
 
 
+def _settle(w, rounds: int = 60):
+    """Pump until this window's scroll area stops moving.
+
+    THE MEASUREMENT USED TO BE TAKEN MID-LAYOUT, AND IT IS WHY THIS FILE WAS
+    NONDETERMINISTIC. `ModalDriver` acts on the first 5 ms tick at which
+    `activeModalWidget()` is not None — which is before Qt has finished
+    `QScrollAreaPrivate::updateScrollBars`. Measured on this tree, 2026-09-06,
+    the consent window with the fonts registered, first tick against settled:
+
+        ru   vp_w 498 hbar_visible True  ->  vp_w 512 hbar_visible False
+        no   vp_h 354 hbar_visible True  ->  vp_h 368 hbar_visible False
+        en   vp_w 498                    ->  vp_w 512
+
+    `hbar.maximum()` is **0 at both moments** in every language: nothing is
+    scrolled anywhere, the bar is raised and withdrawn again inside one layout
+    pass, and a test that reads `isVisible()` in that window reports a window
+    that "scrolls sideways" when it does not. Which language is caught depends
+    on how loaded the machine is, which is exactly the shape the owner saw:
+    the same command, the same commit, three runs — 13 passed, 13 passed,
+    4 failed (zh_CN among them), and fr/no/ru/no on four further runs.
+
+    Nothing here relaxes an assertion. The numbers are simply read once the
+    layout has stopped changing them, which is what `_settle` does in
+    `test_the_manual_panel_does_not_scroll_sideways.py` for the same reason.
+    """
+    from PyQt6.QtWidgets import QApplication, QScrollArea
+    areas = w.findChildren(QScrollArea)
+    if not areas:
+        return
+    area = areas[0]
+    last = None
+    for _ in range(rounds):
+        QApplication.processEvents()
+        now = (w.height(), w.width(), area.viewport().width(),
+               area.viewport().height(),
+               area.horizontalScrollBar().maximum(),
+               area.horizontalScrollBar().isVisible(),
+               area.verticalScrollBar().maximum())
+        if now == last:
+            return
+        last = now
+
+
 def _geometry_of(w):
     """Everything these tests need, read while the window is still alive."""
     from PyQt6.QtCore import Qt
     from PyQt6.QtWidgets import QPushButton, QScrollArea
+    _settle(w)
     area = w.findChildren(QScrollArea)[0]
     vbar, hbar = area.verticalScrollBar(), area.horizontalScrollBar()
     inner = area.widget()


### PR DESCRIPTION
**This is the branch the macOS host asked the Windows VM to finish** (handover round 5, §1). It is `proposed/offscreen-font-metrics` plus the recalibration work, measured on Windows/ARM64 where the fault is visible.

## The fault

Under `QT_QPA_PLATFORM=offscreen` on Windows with Qt 6.11, `QFontDatabase.families()` returns an **empty list**. Qt then draws every glyph as a tofu box of `pixelSize`, so `w("i") == w("W") == 13`, while `ui/styles.py` asks for Inter on every widget. "Manuelle Einstellungen" measures **286 px** as tofu against **144 px** in real Inter — a 1.99x overestimate under every widget on screen.

So every geometry assertion in the suite has been measuring a font that does not exist, and it is wrong in **both** directions: it reports clipping that is not there, and it cannot see clipping that is.

`tests/conftest.py` now registers the fonts the app bundles, in the same position `main()` does — one line above the `setStyle` the fixture already mirrors, for the reason the file's own docstring gives: *a gate should measure what ships*.

## Why macOS measured "no change" and that is the argument FOR this

On macOS, registering changed nothing: 11311 passed both ways, 0 status changes across 11,471 items. The reason is the finding — `families()` is 197 before and after, because that machine already has Inter, JetBrains Mono and Instrument Serif in `~/Library/Fonts`. **The macOS gate is currently green by accident of one person's font folder.** On a fresh clone, another developer's Mac or a CI runner, Inter falls back and every metric shifts.

## The delta, full suite, `--runslow -n auto`, Windows/ARM64

| | passed | failed | skipped | wall |
|---|---|---|---|---|
| `origin/master` `38ed485d` | 11032 | **128** | 308 | 28:47 |
| this branch | **11122** | **78** | 268 | 36:42 |

Per test across 11,471 JUnit items: **55 fixed, 2 broken, 37 skip→pass, 3 skip→FAIL, 73 failing both ways.**

## A flake removed, not just tests recalibrated

`test_the_driver_window_opens_at_the_height_its_content_wants` and the consent-button tests were a **coin flip on unmodified master**: three identical runs gave `13 passed`, `13 passed`, `4 failed`, and the failing language differed every time (`fr`, then `no`, `ru`, `no`, `pl/pt`, `es/ja/pt/zh_CN`).

Root cause: `ModalDriver` fires on the first 5 ms tick and `_geometry_of` reads `hbar.isVisible()` **mid-`updateScrollBars`**. Driven at both moments: ru `vp_w=498 hbar_visible=True` settling to `512 / False`. `hbar.maximum()` is 0 at both moments in every language — nothing was ever actually clipped. A `_settle()` fixes it with **no assertion touched**: all 13 languages now pass **5/5**, where master flips 8 of 13 within five runs.

## 40 tests that had never once executed on Windows

`tests/_fontcheck.py::skip_without_fonts()` guards 25 call sites across 12 files and fires on every Windows offscreen run. Registering the fonts unskips them: **36 pass, 4 fail.** A pass→fail delta structurally cannot see these, which is why the first estimate of this work was wrong.

## Recalibrated — each measured, each run 5× in both states

* **indent control** — `assert 208 < 208`, an exact tie. Russian is the only genuinely clipped language (289 given / 317 needed); German is a dead tie. Now runs in Russian.
* **button min-width** — text is 65 px but the declared width is 72, the floor at `ui/widgets.py:318`. The floor is now in the bound. (It is a minimum **width**, not height.)
* **legend rows** — five labels measure 432 px and fit; the narrow width is now derived from the labels.
* **run combo** — the 120 px threshold *was itself* a glyph measurement (`advance("Run 8 (overwrite)") + 44` = 117).
* **`…labels_cost_something_is_on`** — 200 was a macOS/Menlo figure; German reaches the layout at 166. Now pins the mechanism.
* **preset-row control** — no language overflows any more (de 537, sv 536, ru 531 vs 540); re-stated as the mechanism.

**No assertion was weakened, skipped or xfailed to obtain any of this.**

## LEFT RED ON PURPOSE — these are real defects the tofu was hiding

A red test that names a real defect is a better outcome than a green one that hides it.

* **`test_file_guide_structure` ×2 — D6.** `ui/file_guide.py:68`'s `_MONO` omits the JetBrains Mono the app bundles (unlike `styles.py:387`, `light_styles.py:387`, `neutral_styles.py:524`, `masthead_header.py:397`). Every unbundled family now resolves to Instrument Serif, connectors measure 14/19/24 px and the tree is crooked. One-word fix, deliberately out of scope here. **It was passing vacuously before.**
* **`test_help_card_width` ×2** — driven on the real Windows screen: the `-T` card needs **383 px in a 372 px label** and re-wraps. `_InfoDialog.__init__` measures the hand-wrapped width *before polish*, so it asks for the system font's width rather than Inter's.
* **`…hides_none_of_itself`** — a 48 px empty band: `ContentHeightScrollArea.sizeHint` returns `max(base.height(), content)` and Qt's `24 × 16` floor (368) beats the 320 the notice needs.
* **`[nl]` + `[nl-engine]`** — the genuine **4 px Dutch overflow** (518 needed vs 514 available). Red in both states. The fix lives in `ui/dialogs/layout_options_panel.py`, which was fenced off for this branch.

macOS independently measured Dutch at **514 px against a 514 px budget — zero spare**, which is the argument against simply skipping the family on Windows.

## Note for macOS

`addApplicationFont` returns **-1** once anything has populated the CoreText database — a bare `families()` call is enough. The registration must happen before the first query or it is a silent no-op **that still gates green**. The mutation was proved to land: `applicationFontFamilies(0)` → `['Instrument Serif']` inside a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXFQwMgD9Uc6ZfySU2gXKB
